### PR TITLE
feat: Add ManagedRefresh capability for smart refresh scheduling

### DIFF
--- a/lib/chroma_wave.rb
+++ b/lib/chroma_wave.rb
@@ -34,6 +34,8 @@ require_relative 'chroma_wave/capabilities/fast_refresh'     # Fast-refresh disp
 require_relative 'chroma_wave/capabilities/grayscale_mode'   # Grayscale display mode
 require_relative 'chroma_wave/capabilities/dual_buffer'      # Dual-buffer tri-color support
 require_relative 'chroma_wave/capabilities/regional_refresh' # Regional sub-area refresh
+require_relative 'chroma_wave/refresh_scheduler'             # Refresh counter/timer
+require_relative 'chroma_wave/capabilities/managed_refresh'  # Opt-in refresh management
 require_relative 'chroma_wave/display'      # High-level Display with lazy init + capabilities
 require_relative 'chroma_wave/registry'     # Auto-builds Display subclasses from C config
 require_relative 'chroma_wave/mock_device'  # Test-friendly Display with operation logging

--- a/lib/chroma_wave/capabilities/managed_refresh.rb
+++ b/lib/chroma_wave/capabilities/managed_refresh.rb
@@ -119,6 +119,11 @@ module ChromaWave
       # Wraps a partial display operation with interval checking, counter
       # tracking, and optional auto-full-refresh.
       #
+      # The display operation (+yield+) runs first, outside the device lock,
+      # since +super+ already synchronizes its own device I/O internally.
+      # Only scheduler state mutations and auto-full-refresh are performed
+      # under the lock, keeping the critical section minimal.
+      #
       # @param framebuffer [Framebuffer] the framebuffer being displayed
       # @param auto_refresh [Boolean] whether to trigger auto-full-refresh
       #   when the partial limit is reached (default: +true+). Disabled for
@@ -126,8 +131,8 @@ module ChromaWave
       # @yield the display operation to wrap (must call +super+)
       # @return [self]
       def _with_partial_tracking(framebuffer, auto_refresh: true)
+        yield
         synchronize_device do
-          yield
           refresh_scheduler.check_interval!
           refresh_scheduler.track_partial!
           _auto_full_refresh!(framebuffer) if auto_refresh && _should_auto_refresh?
@@ -137,11 +142,15 @@ module ChromaWave
 
       # Wraps a full display operation with interval checking and counter reset.
       #
+      # The display operation (+yield+) runs first, outside the device lock,
+      # since +super+ already synchronizes its own device I/O internally.
+      # Only scheduler state mutations are performed under the lock.
+      #
       # @yield the display operation to wrap (must call +super+)
       # @return [self]
       def _with_full_tracking
+        yield
         synchronize_device do
-          yield
           refresh_scheduler.check_interval!
           refresh_scheduler.track_full!
         end

--- a/lib/chroma_wave/capabilities/managed_refresh.rb
+++ b/lib/chroma_wave/capabilities/managed_refresh.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+module ChromaWave
+  module Capabilities
+    # Opt-in capability that wraps display methods with automatic refresh scheduling.
+    #
+    # Mixed in via +extend+ on individual Display instances when +managed_refresh:+
+    # is passed to {Display.new} or {MockDevice.new}. Because it is +extend+ed
+    # (not +include+d), it only affects the specific instance, keeping the default
+    # behavior unchanged for other instances of the same class.
+    #
+    # Wraps 7 display methods:
+    # - **Partial trackers** (+display_partial+, +display_fast+, +display_region+):
+    #   increment the partial counter after each call. +display_partial+ and
+    #   +display_fast+ may trigger an automatic maintenance full refresh when the
+    #   partial limit is reached. +display_region+ skips auto-refresh (sub-region only).
+    # - **Full trackers** (+show+, +display_base+, +display_grayscale+, +clear+):
+    #   reset the partial counter after each call.
+    #
+    # Requires the Device to use a reentrant lock (Monitor) since wrappers
+    # call +synchronize_device+ around +super+, which itself synchronizes.
+    #
+    # @example
+    #   display = Display.new(model: :epd_2in13_v4, managed_refresh: true)
+    #   display.refresh_scheduler.partial_count  # => 0
+    #   5.times { display.display_partial(fb) }  # auto-triggers full refresh on 5th
+    #
+    # @see RefreshScheduler
+    module ManagedRefresh
+      # Returns the refresh scheduler for this display instance.
+      #
+      # @return [RefreshScheduler]
+      attr_reader :refresh_scheduler
+
+      # --- Partial trackers ---
+
+      # Displays a framebuffer using partial refresh, tracking the refresh count.
+      #
+      # When the partial limit is reached and +auto_full_refresh+ is enabled,
+      # a maintenance full refresh is performed first to clear ghosting artifacts,
+      # then the partial display proceeds.
+      #
+      # @param framebuffer [Framebuffer] the framebuffer to display
+      # @return [self]
+      def display_partial(framebuffer)
+        validate_framebuffer!(framebuffer)
+        synchronize_device do
+          refresh_scheduler.check_interval!
+          refresh_scheduler.track_partial!
+          _auto_full_refresh!(framebuffer) if _should_auto_refresh?
+          super
+        end
+        self
+      end
+
+      # Displays a framebuffer using fast refresh, tracking the refresh count.
+      #
+      # When the partial limit is reached and +auto_full_refresh+ is enabled,
+      # a maintenance full refresh is performed first.
+      #
+      # @param framebuffer [Framebuffer] the framebuffer to display
+      # @return [self]
+      def display_fast(framebuffer)
+        validate_framebuffer!(framebuffer)
+        synchronize_device do
+          refresh_scheduler.check_interval!
+          refresh_scheduler.track_partial!
+          _auto_full_refresh!(framebuffer) if _should_auto_refresh?
+          super
+        end
+        self
+      end
+
+      # Displays a sub-region, tracking as a partial refresh.
+      #
+      # The partial counter increments but auto-full-refresh is skipped because
+      # only a sub-region framebuffer is available — a full refresh requires a
+      # full-screen framebuffer.
+      #
+      # @param framebuffer [Framebuffer] the full-screen framebuffer (logical space)
+      # @param x [Integer] left edge of the region
+      # @param y [Integer] top edge of the region
+      # @param width [Integer] region width in pixels
+      # @param height [Integer] region height in pixels
+      # @return [self]
+      def display_region(framebuffer, x:, y:, width:, height:)
+        synchronize_device do
+          refresh_scheduler.check_interval!
+          refresh_scheduler.track_partial!
+          # No auto-full-refresh for sub-regions — only a sub-region is available
+          super
+        end
+        self
+      end
+
+      # --- Full trackers ---
+
+      # Shows content on the display, tracking as a full refresh.
+      #
+      # Resolves Layout input to Canvas before delegating to avoid double-tracking
+      # from Layout's recursive +show+ call.
+      #
+      # @param canvas_or_fb [Canvas, Layout, Framebuffer] content to display
+      # @return [self]
+      def show(canvas_or_fb)
+        canvas_or_fb = canvas_or_fb.render if canvas_or_fb.is_a?(Layout)
+        synchronize_device do
+          refresh_scheduler.check_interval!
+          super(canvas_or_fb)
+          refresh_scheduler.track_full!
+        end
+        self
+      end
+
+      # Displays a base image for subsequent partial updates, tracking as a full refresh.
+      #
+      # @param framebuffer [Framebuffer] the base framebuffer
+      # @return [self]
+      def display_base(framebuffer)
+        synchronize_device do
+          refresh_scheduler.check_interval!
+          super
+          refresh_scheduler.track_full!
+        end
+        self
+      end
+
+      # Displays a framebuffer using grayscale mode, tracking as a full refresh.
+      #
+      # @param framebuffer [Framebuffer] the framebuffer to display
+      # @return [self]
+      def display_grayscale(framebuffer)
+        synchronize_device do
+          refresh_scheduler.check_interval!
+          super
+          refresh_scheduler.track_full!
+        end
+        self
+      end
+
+      # Clears the display, tracking as a full refresh.
+      #
+      # @param color [Symbol] palette color name (default: +:white+)
+      # @return [self]
+      def clear(color: :white)
+        synchronize_device do
+          refresh_scheduler.check_interval!
+          super
+          refresh_scheduler.track_full!
+        end
+        self
+      end
+
+      private
+
+      # Returns whether an automatic full refresh should be triggered.
+      #
+      # @return [Boolean]
+      def _should_auto_refresh?
+        refresh_scheduler.auto_full_refresh? && refresh_scheduler.needs_full?
+      end
+
+      # Performs an automatic maintenance full refresh to clear ghosting.
+      #
+      # Operates directly on the device to avoid re-entering ManagedRefresh
+      # wrappers (no double interval-check or double tracking). Must be called
+      # while holding the device lock.
+      #
+      # @param framebuffer [Framebuffer] the content to display in the full refresh
+      # @return [void]
+      def _auto_full_refresh!(framebuffer)
+        device.send(:_epd_init, Native::MODE_FULL)
+        device.send(:_epd_display, framebuffer)
+        @current_mode = :full
+        @initialized = true
+        refresh_scheduler.track_full!
+      end
+    end
+  end
+end

--- a/lib/chroma_wave/capabilities/managed_refresh.rb
+++ b/lib/chroma_wave/capabilities/managed_refresh.rb
@@ -46,13 +46,7 @@ module ChromaWave
       # @param framebuffer [Framebuffer] the framebuffer to display
       # @return [self]
       def display_partial(framebuffer)
-        synchronize_device do
-          super
-          refresh_scheduler.check_interval!
-          refresh_scheduler.track_partial!
-          _auto_full_refresh!(framebuffer) if _should_auto_refresh?
-        end
-        self
+        _with_partial_tracking(framebuffer) { super }
       end
 
       # Displays a framebuffer using fast refresh, tracking the refresh count.
@@ -63,13 +57,7 @@ module ChromaWave
       # @param framebuffer [Framebuffer] the framebuffer to display
       # @return [self]
       def display_fast(framebuffer)
-        synchronize_device do
-          super
-          refresh_scheduler.check_interval!
-          refresh_scheduler.track_partial!
-          _auto_full_refresh!(framebuffer) if _should_auto_refresh?
-        end
-        self
+        _with_partial_tracking(framebuffer) { super }
       end
 
       # Displays a sub-region, tracking as a partial refresh.
@@ -85,12 +73,7 @@ module ChromaWave
       # @param height [Integer] region height in pixels
       # @return [self]
       def display_region(framebuffer, x:, y:, width:, height:)
-        synchronize_device do
-          super
-          refresh_scheduler.check_interval!
-          refresh_scheduler.track_partial!
-        end
-        self
+        _with_partial_tracking(framebuffer, auto_refresh: false) { super }
       end
 
       # --- Full trackers ---
@@ -104,12 +87,7 @@ module ChromaWave
       # @return [self]
       def show(canvas_or_fb)
         canvas_or_fb = canvas_or_fb.render if canvas_or_fb.is_a?(Layout)
-        synchronize_device do
-          super(canvas_or_fb)
-          refresh_scheduler.check_interval!
-          refresh_scheduler.track_full!
-        end
-        self
+        _with_full_tracking { super(canvas_or_fb) }
       end
 
       # Displays a base image for subsequent partial updates, tracking as a full refresh.
@@ -117,12 +95,7 @@ module ChromaWave
       # @param framebuffer [Framebuffer] the base framebuffer
       # @return [self]
       def display_base(framebuffer)
-        synchronize_device do
-          super
-          refresh_scheduler.check_interval!
-          refresh_scheduler.track_full!
-        end
-        self
+        _with_full_tracking { super }
       end
 
       # Displays a framebuffer using grayscale mode, tracking as a full refresh.
@@ -130,12 +103,7 @@ module ChromaWave
       # @param framebuffer [Framebuffer] the framebuffer to display
       # @return [self]
       def display_grayscale(framebuffer)
-        synchronize_device do
-          super
-          refresh_scheduler.check_interval!
-          refresh_scheduler.track_full!
-        end
-        self
+        _with_full_tracking { super }
       end
 
       # Clears the display, tracking as a full refresh.
@@ -143,15 +111,42 @@ module ChromaWave
       # @param color [Symbol] palette color name (default: +:white+)
       # @return [self]
       def clear(color: :white)
+        _with_full_tracking { super }
+      end
+
+      private
+
+      # Wraps a partial display operation with interval checking, counter
+      # tracking, and optional auto-full-refresh.
+      #
+      # @param framebuffer [Framebuffer] the framebuffer being displayed
+      # @param auto_refresh [Boolean] whether to trigger auto-full-refresh
+      #   when the partial limit is reached (default: +true+). Disabled for
+      #   regional refreshes which cannot safely trigger a full-screen refresh.
+      # @yield the display operation to wrap (must call +super+)
+      # @return [self]
+      def _with_partial_tracking(framebuffer, auto_refresh: true)
         synchronize_device do
-          super
+          yield
+          refresh_scheduler.check_interval!
+          refresh_scheduler.track_partial!
+          _auto_full_refresh!(framebuffer) if auto_refresh && _should_auto_refresh?
+        end
+        self
+      end
+
+      # Wraps a full display operation with interval checking and counter reset.
+      #
+      # @yield the display operation to wrap (must call +super+)
+      # @return [self]
+      def _with_full_tracking
+        synchronize_device do
+          yield
           refresh_scheduler.check_interval!
           refresh_scheduler.track_full!
         end
         self
       end
-
-      private
 
       # Returns whether an automatic full refresh should be triggered.
       #
@@ -166,11 +161,19 @@ module ChromaWave
       # and state mutation, then tracks the full refresh on the scheduler.
       # Must be called while holding the device lock.
       #
+      # If the full refresh fails (e.g. hardware error), the error is logged
+      # and the counter is reset to avoid retrying on every subsequent partial
+      # call. The partial display that triggered this has already succeeded.
+      #
       # @param framebuffer [Framebuffer] the content to display in the full refresh
       # @return [void]
       def _auto_full_refresh!(framebuffer)
         force_full_refresh!(framebuffer)
         refresh_scheduler.track_full!
+      rescue DeviceError => e
+        warn "[ChromaWave] Auto-full-refresh failed: #{e.message}. " \
+             'Counter reset; next cycle will retry.'
+        refresh_scheduler.reset!
       end
     end
   end

--- a/lib/chroma_wave/capabilities/managed_refresh.rb
+++ b/lib/chroma_wave/capabilities/managed_refresh.rb
@@ -17,6 +17,9 @@ module ChromaWave
     # - **Full trackers** (+show+, +display_base+, +display_grayscale+, +clear+):
     #   reset the partial counter after each call.
     #
+    # Tracking and interval checks occur *after* the display operation succeeds,
+    # ensuring counters and timestamps are not mutated if the underlying call raises.
+    #
     # Requires the Device to use a reentrant lock (Monitor) since wrappers
     # call +synchronize_device+ around +super+, which itself synchronizes.
     #
@@ -37,18 +40,17 @@ module ChromaWave
       # Displays a framebuffer using partial refresh, tracking the refresh count.
       #
       # When the partial limit is reached and +auto_full_refresh+ is enabled,
-      # a maintenance full refresh is performed first to clear ghosting artifacts,
-      # then the partial display proceeds.
+      # a maintenance full refresh is performed after the partial display to
+      # clear ghosting artifacts before the next update.
       #
       # @param framebuffer [Framebuffer] the framebuffer to display
       # @return [self]
       def display_partial(framebuffer)
-        validate_framebuffer!(framebuffer)
         synchronize_device do
+          super
           refresh_scheduler.check_interval!
           refresh_scheduler.track_partial!
           _auto_full_refresh!(framebuffer) if _should_auto_refresh?
-          super
         end
         self
       end
@@ -56,28 +58,27 @@ module ChromaWave
       # Displays a framebuffer using fast refresh, tracking the refresh count.
       #
       # When the partial limit is reached and +auto_full_refresh+ is enabled,
-      # a maintenance full refresh is performed first.
+      # a maintenance full refresh is performed after the fast display.
       #
       # @param framebuffer [Framebuffer] the framebuffer to display
       # @return [self]
       def display_fast(framebuffer)
-        validate_framebuffer!(framebuffer)
         synchronize_device do
+          super
           refresh_scheduler.check_interval!
           refresh_scheduler.track_partial!
           _auto_full_refresh!(framebuffer) if _should_auto_refresh?
-          super
         end
         self
       end
 
       # Displays a sub-region, tracking as a partial refresh.
       #
-      # The partial counter increments but auto-full-refresh is skipped because
-      # only a sub-region framebuffer is available — a full refresh requires a
-      # full-screen framebuffer.
+      # Auto-full-refresh is skipped because the caller intends a regional
+      # update only; a full refresh requires re-initializing the display in
+      # full mode and pushing a complete framebuffer.
       #
-      # @param framebuffer [Framebuffer] the full-screen framebuffer (logical space)
+      # @param framebuffer [Framebuffer] full-screen framebuffer in native orientation
       # @param x [Integer] left edge of the region
       # @param y [Integer] top edge of the region
       # @param width [Integer] region width in pixels
@@ -85,10 +86,9 @@ module ChromaWave
       # @return [self]
       def display_region(framebuffer, x:, y:, width:, height:)
         synchronize_device do
+          super
           refresh_scheduler.check_interval!
           refresh_scheduler.track_partial!
-          # No auto-full-refresh for sub-regions — only a sub-region is available
-          super
         end
         self
       end
@@ -105,8 +105,8 @@ module ChromaWave
       def show(canvas_or_fb)
         canvas_or_fb = canvas_or_fb.render if canvas_or_fb.is_a?(Layout)
         synchronize_device do
-          refresh_scheduler.check_interval!
           super(canvas_or_fb)
+          refresh_scheduler.check_interval!
           refresh_scheduler.track_full!
         end
         self
@@ -118,8 +118,8 @@ module ChromaWave
       # @return [self]
       def display_base(framebuffer)
         synchronize_device do
-          refresh_scheduler.check_interval!
           super
+          refresh_scheduler.check_interval!
           refresh_scheduler.track_full!
         end
         self
@@ -131,8 +131,8 @@ module ChromaWave
       # @return [self]
       def display_grayscale(framebuffer)
         synchronize_device do
-          refresh_scheduler.check_interval!
           super
+          refresh_scheduler.check_interval!
           refresh_scheduler.track_full!
         end
         self
@@ -144,8 +144,8 @@ module ChromaWave
       # @return [self]
       def clear(color: :white)
         synchronize_device do
-          refresh_scheduler.check_interval!
           super
+          refresh_scheduler.check_interval!
           refresh_scheduler.track_full!
         end
         self
@@ -162,17 +162,14 @@ module ChromaWave
 
       # Performs an automatic maintenance full refresh to clear ghosting.
       #
-      # Operates directly on the device to avoid re-entering ManagedRefresh
-      # wrappers (no double interval-check or double tracking). Must be called
-      # while holding the device lock.
+      # Delegates to {Display#force_full_refresh!} for the device interaction
+      # and state mutation, then tracks the full refresh on the scheduler.
+      # Must be called while holding the device lock.
       #
       # @param framebuffer [Framebuffer] the content to display in the full refresh
       # @return [void]
       def _auto_full_refresh!(framebuffer)
-        device.send(:_epd_init, Native::MODE_FULL)
-        device.send(:_epd_display, framebuffer)
-        @current_mode = :full
-        @initialized = true
+        force_full_refresh!(framebuffer)
         refresh_scheduler.track_full!
       end
     end

--- a/lib/chroma_wave/device.rb
+++ b/lib/chroma_wave/device.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require 'monitor'
+
 module ChromaWave
   # Wraps a Waveshare E-Paper display with HAL lifecycle management.
   #
   # The C layer provides alloc/initialize (model lookup, DEV_Module_Init),
   # close, open?, model_name, and private _epd_* bridge methods.
-  # This Ruby reopening adds a Mutex for thread safety and a block-form
+  # This Ruby reopening adds a Monitor for thread safety and a block-form
   # +.open+ for automatic cleanup.
   class Device
     # Adds Ruby-level lifecycle management on top of the C-defined Device class.
@@ -13,18 +15,22 @@ module ChromaWave
     # Prepended onto the C-defined +Device+ so +super+ dispatches to the
     # C +initialize+ method.
     module Lifecycle
-      # Initializes the device for the given model, setting up a mutex for
-      # thread-safe access.
+      # Initializes the device for the given model, setting up a reentrant
+      # monitor for thread-safe access.
+      #
+      # Uses Monitor instead of Mutex to support reentrant locking, which
+      # is required by {Capabilities::ManagedRefresh} when auto-full-refresh
+      # wraps an already-synchronized display call.
       #
       # @param model_name [String] the EPD model identifier (e.g. "epd_2in13_v4")
       # @raise [ChromaWave::ModelNotFoundError] if the model is not in the registry
       # @raise [ChromaWave::InitError] if HAL initialization fails
       def initialize(model_name)
-        @mutex = Mutex.new
+        @mutex = Monitor.new
         super # -> C device_initialize(model_name)
       end
 
-      # Synchronizes access to the device using the internal mutex.
+      # Synchronizes access to the device using the internal monitor.
       #
       # @yield the block to execute while holding the lock
       # @return the block's return value

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -274,6 +274,11 @@ module ChromaWave
     #   scheduler options (see {RefreshScheduler#initialize})
     # @return [void]
     def setup_managed_refresh!(options)
+      if pixel_format == PixelFormat::COLOR4
+        raise ArgumentError,
+              'managed_refresh is not supported on tri-color (COLOR4) displays'
+      end
+
       unless options == true || options.is_a?(Hash)
         raise ArgumentError,
               "managed_refresh must be true or a Hash, got #{options.inspect} (#{options.class})"

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -29,18 +29,21 @@ module ChromaWave
     #
     # @param model [Symbol, String] model name (e.g. +:epd_2in13_v4+)
     # @param rotation [Integer] display rotation in degrees (0, 90, 180, 270)
+    # @param managed_refresh [Boolean, Hash, nil] opt-in refresh scheduling.
+    #   Pass +true+ for defaults, or a Hash with +:partial_limit+, +:min_interval+,
+    #   and/or +:auto_full_refresh+ keys. +nil+ (default) disables scheduling.
     # @return [Display] a subclass instance with appropriate capabilities
     # @raise [ModelNotFoundError] if the model is not in the registry
-    def self.new(model: nil, rotation: 0, **kwargs)
+    def self.new(model: nil, rotation: 0, managed_refresh: nil, **kwargs)
       if self == Display
         raise ArgumentError, 'missing keyword: :model' unless model
         raise ArgumentError, "unknown keyword(s): #{kwargs.keys.join(', ')}" unless kwargs.empty?
 
-        return Registry.build(model, rotation: rotation)
+        return Registry.build(model, rotation: rotation, managed_refresh: managed_refresh)
       end
 
       instance = allocate
-      instance.send(:initialize, rotation: rotation, **kwargs)
+      instance.send(:initialize, rotation: rotation, managed_refresh: managed_refresh, **kwargs)
       instance
     end
 
@@ -50,10 +53,11 @@ module ChromaWave
     #
     # @param model [Symbol, String] model name
     # @param rotation [Integer] display rotation in degrees (0, 90, 180, 270)
+    # @param managed_refresh [Boolean, Hash, nil] opt-in refresh scheduling
     # @yield [display] the opened display
     # @return [Display, Object] the display (no block) or the block's return value
-    def self.open(model:, rotation: 0)
-      display = new(model: model, rotation: rotation)
+    def self.open(model:, rotation: 0, managed_refresh: nil)
+      display = new(model: model, rotation: rotation, managed_refresh: managed_refresh)
       return display unless block_given?
 
       begin
@@ -176,7 +180,8 @@ module ChromaWave
     # @param model_name [Symbol, String] the model identifier
     # @param config [Hash] the model configuration from {Native.model_config}
     # @param rotation [Integer] display rotation in degrees (0, 90, 180, 270)
-    def initialize(model_name:, config:, rotation: 0)
+    # @param managed_refresh [Boolean, Hash, nil] opt-in refresh scheduling
+    def initialize(model_name:, config:, rotation: 0, managed_refresh: nil)
       validate_rotation!(rotation)
       @model = model_name.to_sym
       @rotation = rotation
@@ -188,6 +193,7 @@ module ChromaWave
       @current_mode = nil
 
       apply_logical_dimensions!
+      setup_managed_refresh!(managed_refresh) if managed_refresh
     end
 
     private
@@ -242,6 +248,21 @@ module ChromaWave
         @width = @native_width
         @height = @native_height
       end
+    end
+
+    # Configures managed refresh scheduling for this instance.
+    #
+    # Creates a {RefreshScheduler} and extends this instance with
+    # {Capabilities::ManagedRefresh} to wrap display methods with
+    # automatic refresh tracking.
+    #
+    # @param options [Boolean, Hash] +true+ for defaults, or a Hash of
+    #   scheduler options (see {RefreshScheduler#initialize})
+    # @return [void]
+    def setup_managed_refresh!(options)
+      opts = options == true ? {} : options
+      @refresh_scheduler = RefreshScheduler.new(**opts)
+      extend Capabilities::ManagedRefresh
     end
 
     # Validates that a framebuffer's pixel format and dimensions match this display.

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -274,6 +274,11 @@ module ChromaWave
     #   scheduler options (see {RefreshScheduler#initialize})
     # @return [void]
     def setup_managed_refresh!(options)
+      unless options == true || options.is_a?(Hash)
+        raise ArgumentError,
+              "managed_refresh must be true or a Hash, got #{options.inspect} (#{options.class})"
+      end
+
       opts = options == true ? {} : options
       @refresh_scheduler = RefreshScheduler.new(**opts)
       extend Capabilities::ManagedRefresh

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -200,6 +200,20 @@ module ChromaWave
 
     attr_reader :device, :current_mode
 
+    # Forces a full-mode initialization and display cycle on the device.
+    #
+    # Used by {Capabilities::ManagedRefresh} for automatic maintenance refreshes.
+    # Must be called while holding the device lock.
+    #
+    # @param framebuffer [Framebuffer] the content to display
+    # @return [void]
+    def force_full_refresh!(framebuffer)
+      device.send(:_epd_init, Native::MODE_FULL)
+      device.send(:_epd_display, framebuffer)
+      @current_mode = :full
+      @initialized = true
+    end
+
     # Lazily initializes the EPD on first use with full refresh mode.
     #
     # Thread-safe: always synchronizes the @initialized check to prevent

--- a/lib/chroma_wave/mock_device.rb
+++ b/lib/chroma_wave/mock_device.rb
@@ -27,9 +27,10 @@ module ChromaWave
       # @param model [Symbol, String] model name (e.g. +:epd_2in13_v4+)
       # @param rotation [Integer] display rotation in degrees (0, 90, 180, 270)
       # @param busy_duration [Numeric] simulated refresh delay in seconds
+      # @param managed_refresh [Boolean, Hash, nil] opt-in refresh scheduling
       # @return [MockDevice]
       # @raise [ModelNotFoundError] if the model is not in the registry
-      def new(model: nil, rotation: 0, busy_duration: 0, **kwargs)
+      def new(model: nil, rotation: 0, busy_duration: 0, managed_refresh: nil, **kwargs)
         raise ArgumentError, 'missing keyword: :model' unless model
         raise ArgumentError, "unknown keyword(s): #{kwargs.keys.join(', ')}" unless kwargs.empty?
 
@@ -40,7 +41,8 @@ module ChromaWave
         klass = mock_classes[name] ||= build_mock_class(config)
         instance = klass.allocate
         instance.send(:initialize, model_name: name, config: config,
-                                   rotation: rotation, busy_duration: busy_duration)
+                                   rotation: rotation, busy_duration: busy_duration,
+                                   managed_refresh: managed_refresh)
         instance
       end
 
@@ -49,10 +51,12 @@ module ChromaWave
       # @param model [Symbol, String] model name
       # @param rotation [Integer] display rotation in degrees (0, 90, 180, 270)
       # @param busy_duration [Numeric] simulated refresh delay in seconds
+      # @param managed_refresh [Boolean, Hash, nil] opt-in refresh scheduling
       # @yield [mock] the opened MockDevice
       # @return [MockDevice, Object] the mock (no block) or the block's return value
-      def open(model:, rotation: 0, busy_duration: 0)
-        mock = new(model: model, rotation: rotation, busy_duration: busy_duration)
+      def open(model:, rotation: 0, busy_duration: 0, managed_refresh: nil)
+        mock = new(model: model, rotation: rotation, busy_duration: busy_duration,
+                   managed_refresh: managed_refresh)
         return mock unless block_given?
 
         begin
@@ -192,7 +196,8 @@ module ChromaWave
     # @param config [Hash] the model configuration from Native
     # @param rotation [Integer] display rotation in degrees (0, 90, 180, 270)
     # @param busy_duration [Numeric] simulated refresh delay in seconds
-    def initialize(model_name:, config:, rotation: 0, busy_duration: 0) # rubocop:disable Lint/MissingSuper -- intentionally avoids Display#initialize which creates a real C Device
+    # @param managed_refresh [Boolean, Hash, nil] opt-in refresh scheduling
+    def initialize(model_name:, config:, rotation: 0, busy_duration: 0, managed_refresh: nil) # rubocop:disable Lint/MissingSuper -- intentionally avoids Display#initialize which creates a real C Device
       validate_rotation!(rotation)
       @model = model_name.to_sym
       @rotation = rotation
@@ -208,6 +213,7 @@ module ChromaWave
       @last_red_plane = nil
       @device = DeviceStub.new(self)
       apply_logical_dimensions!
+      setup_managed_refresh!(managed_refresh) if managed_refresh
     end
 
     private
@@ -352,7 +358,7 @@ module ChromaWave
       # @param mock_device [MockDevice] the owning mock device
       def initialize(mock_device)
         @mock_device = mock_device
-        @mutex = Mutex.new
+        @mutex = Monitor.new
         @open = true
       end
 

--- a/lib/chroma_wave/mock_device.rb
+++ b/lib/chroma_wave/mock_device.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'did_you_mean'
+require 'monitor'
 
 module ChromaWave
   # Test-friendly Display replacement that logs operations without touching hardware.

--- a/lib/chroma_wave/refresh_scheduler.rb
+++ b/lib/chroma_wave/refresh_scheduler.rb
@@ -28,11 +28,7 @@ module ChromaWave
     # Creates a new RefreshScheduler with configurable thresholds.
     #
     # @param partial_limit [Integer] number of partial refreshes before a full refresh
-    #   is recommended (default: {DEFAULT_PARTIAL_LIMIT})
-    # @note A +partial_limit+ of 0 causes {#needs_full?} to return +true+
-    #   immediately. Combined with +auto_full_refresh: true+, this triggers a
-    #   maintenance full refresh on every partial call, effectively negating the
-    #   benefits of partial refresh.
+    #   is recommended (default: {DEFAULT_PARTIAL_LIMIT}). Must be >= 1.
     # @param min_interval [Numeric] minimum seconds between refreshes before a
     #   warning is issued (default: {DEFAULT_MIN_INTERVAL})
     # @param auto_full_refresh [Boolean] whether to automatically trigger a full
@@ -40,6 +36,7 @@ module ChromaWave
     def initialize(partial_limit: DEFAULT_PARTIAL_LIMIT,
                    min_interval: DEFAULT_MIN_INTERVAL,
                    auto_full_refresh: true)
+      validate_params!(partial_limit, min_interval)
       @partial_limit = partial_limit
       @min_interval = min_interval
       @auto_full_refresh = auto_full_refresh
@@ -104,6 +101,17 @@ module ChromaWave
     end
 
     private
+
+    # Validates constructor parameters.
+    #
+    # @param partial_limit [Integer] must be >= 1
+    # @param min_interval [Numeric] must be >= 0
+    # @raise [ArgumentError] if values are out of range
+    # @return [void]
+    def validate_params!(partial_limit, min_interval)
+      raise ArgumentError, "partial_limit must be >= 1, got #{partial_limit}" if partial_limit < 1
+      raise ArgumentError, "min_interval must be >= 0, got #{min_interval}" if min_interval.negative?
+    end
 
     # Returns the current monotonic time for interval measurement.
     #

--- a/lib/chroma_wave/refresh_scheduler.rb
+++ b/lib/chroma_wave/refresh_scheduler.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module ChromaWave
+  # Tracks partial refresh counts and enforces minimum intervals between refreshes.
+  #
+  # E-paper displays accumulate ghosting artifacts after repeated partial refreshes.
+  # Waveshare recommends periodic full refreshes to clear this. RefreshScheduler
+  # is a pure data/logic class (no hardware interaction) that tracks refresh counts,
+  # warns on rapid-fire updates, and signals when a maintenance full refresh is due.
+  #
+  # Used internally by {Capabilities::ManagedRefresh}; not typically instantiated
+  # directly.
+  #
+  # @example
+  #   scheduler = RefreshScheduler.new(partial_limit: 5, min_interval: 180)
+  #   scheduler.track_partial!
+  #   scheduler.partial_count   # => 1
+  #   scheduler.needs_full?     # => false
+  class RefreshScheduler
+    # Default number of partial refreshes before a full refresh is recommended.
+    DEFAULT_PARTIAL_LIMIT = 5
+
+    # Default minimum interval (seconds) between refreshes before a warning is issued.
+    DEFAULT_MIN_INTERVAL = 180
+
+    attr_reader :partial_count, :last_refresh_at, :partial_limit, :min_interval
+
+    # Creates a new RefreshScheduler with configurable thresholds.
+    #
+    # @param partial_limit [Integer] number of partial refreshes before a full refresh
+    #   is recommended (default: {DEFAULT_PARTIAL_LIMIT})
+    # @param min_interval [Numeric] minimum seconds between refreshes before a
+    #   warning is issued (default: {DEFAULT_MIN_INTERVAL})
+    # @param auto_full_refresh [Boolean] whether to automatically trigger a full
+    #   refresh when the partial limit is reached (default: +true+)
+    def initialize(partial_limit: DEFAULT_PARTIAL_LIMIT,
+                   min_interval: DEFAULT_MIN_INTERVAL,
+                   auto_full_refresh: true)
+      @partial_limit = partial_limit
+      @min_interval = min_interval
+      @auto_full_refresh = auto_full_refresh
+      @partial_count = 0
+      @last_refresh_at = nil
+    end
+
+    # Records a partial refresh, incrementing the counter and updating the timestamp.
+    #
+    # @return [void]
+    def track_partial!
+      @partial_count += 1
+      @last_refresh_at = current_time
+    end
+
+    # Records a full refresh, resetting the counter and updating the timestamp.
+    #
+    # @return [void]
+    def track_full!
+      @partial_count = 0
+      @last_refresh_at = current_time
+    end
+
+    # Warns via +Kernel#warn+ if less than {#min_interval} seconds have elapsed
+    # since the last refresh.
+    #
+    # No-op on the first refresh (when {#last_refresh_at} is +nil+).
+    #
+    # @return [void]
+    def check_interval!
+      return unless last_refresh_at
+
+      elapsed = current_time - last_refresh_at
+      return unless elapsed < min_interval
+
+      warn '[ChromaWave] Refresh interval too short ' \
+           "(#{elapsed.round(1)}s < #{min_interval}s minimum). " \
+           'Frequent refreshes may cause ghosting or damage the display.'
+    end
+
+    # Returns whether the partial refresh count has reached the configured limit.
+    #
+    # @return [Boolean]
+    def needs_full?
+      partial_count >= partial_limit
+    end
+
+    # Returns whether automatic full refresh is enabled.
+    #
+    # @return [Boolean]
+    def auto_full_refresh?
+      @auto_full_refresh
+    end
+
+    # Resets the partial counter to zero without changing the timestamp.
+    #
+    # Useful for manually acknowledging the counter without performing a full refresh.
+    #
+    # @return [void]
+    def reset!
+      @partial_count = 0
+    end
+
+    private
+
+    # Returns the current monotonic time for interval measurement.
+    #
+    # Uses the monotonic clock to avoid issues with system clock adjustments.
+    #
+    # @return [Float] seconds since an arbitrary fixed point
+    def current_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/chroma_wave/refresh_scheduler.rb
+++ b/lib/chroma_wave/refresh_scheduler.rb
@@ -29,6 +29,10 @@ module ChromaWave
     #
     # @param partial_limit [Integer] number of partial refreshes before a full refresh
     #   is recommended (default: {DEFAULT_PARTIAL_LIMIT})
+    # @note A +partial_limit+ of 0 causes {#needs_full?} to return +true+
+    #   immediately. Combined with +auto_full_refresh: true+, this triggers a
+    #   maintenance full refresh on every partial call, effectively negating the
+    #   benefits of partial refresh.
     # @param min_interval [Numeric] minimum seconds between refreshes before a
     #   warning is issued (default: {DEFAULT_MIN_INTERVAL})
     # @param auto_full_refresh [Boolean] whether to automatically trigger a full

--- a/lib/chroma_wave/registry.rb
+++ b/lib/chroma_wave/registry.rb
@@ -27,9 +27,10 @@ module ChromaWave
       #
       # @param model [Symbol, String] model name (e.g. +:epd_2in13_v4+)
       # @param rotation [Integer] display rotation in degrees (0, 90, 180, 270)
+      # @param managed_refresh [Boolean, Hash, nil] opt-in refresh scheduling
       # @return [Display]
       # @raise [ModelNotFoundError] if the model is not in the registry
-      def build(model, rotation: 0)
+      def build(model, rotation: 0, managed_refresh: nil)
         name = model.to_s
         config = Native.model_config(name)
         raise_not_found!(name) unless config
@@ -37,7 +38,8 @@ module ChromaWave
         klass = CACHE_MUTEX.synchronize do
           display_classes[name] ||= build_class(name, config)
         end
-        klass.send(:new, model_name: name, config: config, rotation: rotation)
+        klass.send(:new, model_name: name, config: config,
+                         rotation: rotation, managed_refresh: managed_refresh)
       end
 
       # Returns all registered model names as symbols.

--- a/spec/chroma_wave/capabilities/managed_refresh_spec.rb
+++ b/spec/chroma_wave/capabilities/managed_refresh_spec.rb
@@ -134,6 +134,16 @@ RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
       display.display_grayscale(fb)
       expect(display.refresh_scheduler.partial_count).to eq(0)
     end
+
+    it 'resumes accumulating partials after grayscale reset' do
+      fb = make_framebuffer(display)
+      2.times { display.display_partial(fb) }
+      display.display_grayscale(fb)
+      expect(display.refresh_scheduler.partial_count).to eq(0)
+
+      2.times { display.display_partial(fb) }
+      expect(display.refresh_scheduler.partial_count).to eq(2)
+    end
   end
 
   describe 'regional refresh tracking' do
@@ -142,7 +152,7 @@ RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
     end
 
     it 'increments counter on display_region' do
-      fb = ChromaWave::Framebuffer.new(display.width, display.height, display.pixel_format)
+      fb = make_framebuffer(display)
       display.display_region(fb, x: 0, y: 0, width: 8, height: 8)
       expect(display.refresh_scheduler.partial_count).to eq(1)
     end
@@ -156,7 +166,7 @@ RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
       end
 
       before do
-        fb = ChromaWave::Framebuffer.new(display.width, display.height, display.pixel_format)
+        fb = make_framebuffer(display)
         display.display_region(fb, x: 0, y: 0, width: 8, height: 8)
         display.clear_operations!
         2.times { display.display_region(fb, x: 0, y: 0, width: 8, height: 8) }
@@ -200,11 +210,11 @@ RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
       fb = make_framebuffer(display)
       3.times { display.display_partial(fb) }
 
-      # 3rd call: track_partial!(count=3), auto-refresh(track_full! → count=0), super
+      # 3rd call: super, track_partial!(count=3), auto-refresh(track_full! → count=0)
       expect(display.refresh_scheduler.partial_count).to eq(0)
     end
 
-    it 'shows full init followed by partial init in operation log' do
+    it 'shows partial init then full init in operation log' do
       fb = make_framebuffer(display)
       3.times { display.display_partial(fb) }
 
@@ -212,8 +222,8 @@ RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
       init_modes = init_ops.map { |o| o[:mode] }
 
       # 1st partial inits partial mode, 2nd reuses it (no re-init),
-      # 3rd triggers full refresh then re-inits partial for the actual display
-      expect(init_modes).to eq(%i[partial full partial])
+      # 3rd displays partial then auto-full-refresh triggers full init
+      expect(init_modes).to eq(%i[partial full])
     end
 
     context 'when auto_full_refresh is disabled' do

--- a/spec/chroma_wave/capabilities/managed_refresh_spec.rb
+++ b/spec/chroma_wave/capabilities/managed_refresh_spec.rb
@@ -1,0 +1,382 @@
+# frozen_string_literal: true
+
+RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
+  # epd_2in13_v4: mono, 122x250, has :partial, :fast, :dual_buf
+  let(:model) { :epd_2in13_v4 }
+
+  # epd_2in7_v2: mono, 176x264, has :partial, :fast, :grayscale, :regional
+  let(:regional_model) { :epd_2in7_v2 }
+
+  after { display&.close }
+
+  def make_framebuffer(disp)
+    ChromaWave::Framebuffer.new(disp.native_width, disp.native_height, disp.pixel_format)
+  end
+
+  def make_canvas(disp)
+    ChromaWave::Canvas.new(width: disp.width, height: disp.height)
+  end
+
+  describe 'opt-in behavior' do
+    context 'when managed_refresh is not set' do
+      let(:display) { ChromaWave::MockDevice.new(model: model) }
+
+      it 'does not have a refresh_scheduler' do
+        expect(display).not_to respond_to(:refresh_scheduler)
+      end
+
+      it 'is not extended with ManagedRefresh' do
+        expect(display).not_to be_a(described_class)
+      end
+    end
+
+    context 'when managed_refresh: true' do
+      let(:display) { ChromaWave::MockDevice.new(model: model, managed_refresh: true) }
+
+      it 'has a refresh_scheduler' do
+        expect(display.refresh_scheduler).to be_a(ChromaWave::RefreshScheduler)
+      end
+
+      it 'is extended with ManagedRefresh' do
+        expect(display).to be_a(described_class)
+      end
+
+      it 'uses default scheduler options' do
+        expect(display.refresh_scheduler.partial_limit).to eq(5)
+        expect(display.refresh_scheduler.min_interval).to eq(180)
+        expect(display.refresh_scheduler.auto_full_refresh?).to be true
+      end
+    end
+
+    context 'when managed_refresh: { ... } with custom options' do
+      let(:display) do
+        ChromaWave::MockDevice.new(
+          model: model,
+          managed_refresh: { partial_limit: 10, min_interval: 60, auto_full_refresh: false }
+        )
+      end
+
+      it 'uses custom scheduler options' do
+        expect(display.refresh_scheduler.partial_limit).to eq(10)
+        expect(display.refresh_scheduler.min_interval).to eq(60)
+        expect(display.refresh_scheduler.auto_full_refresh?).to be false
+      end
+    end
+  end
+
+  describe 'partial tracking' do
+    let(:display) do
+      ChromaWave::MockDevice.new(model: model, managed_refresh: { min_interval: 0 })
+    end
+
+    it 'increments counter on display_partial' do
+      fb = make_framebuffer(display)
+      display.display_partial(fb)
+      expect(display.refresh_scheduler.partial_count).to eq(1)
+    end
+
+    it 'increments counter on display_fast' do
+      fb = make_framebuffer(display)
+      display.display_fast(fb)
+      expect(display.refresh_scheduler.partial_count).to eq(1)
+    end
+
+    it 'accumulates across multiple partial calls' do
+      fb = make_framebuffer(display)
+      3.times { display.display_partial(fb) }
+      expect(display.refresh_scheduler.partial_count).to eq(3)
+    end
+
+    it 'accumulates mixed partial and fast calls' do
+      fb = make_framebuffer(display)
+      display.display_partial(fb)
+      display.display_fast(fb)
+      display.display_partial(fb)
+      expect(display.refresh_scheduler.partial_count).to eq(3)
+    end
+  end
+
+  describe 'full refresh tracking' do
+    let(:display) do
+      ChromaWave::MockDevice.new(model: model, managed_refresh: { min_interval: 0 })
+    end
+
+    it 'resets counter on show' do
+      fb = make_framebuffer(display)
+      3.times { display.display_partial(fb) }
+      display.show(fb)
+      expect(display.refresh_scheduler.partial_count).to eq(0)
+    end
+
+    it 'resets counter on clear' do
+      fb = make_framebuffer(display)
+      3.times { display.display_partial(fb) }
+      display.clear
+      expect(display.refresh_scheduler.partial_count).to eq(0)
+    end
+
+    it 'resets counter on display_base' do
+      fb = make_framebuffer(display)
+      3.times { display.display_partial(fb) }
+      display.display_base(fb)
+      expect(display.refresh_scheduler.partial_count).to eq(0)
+    end
+  end
+
+  describe 'grayscale tracking' do
+    let(:display) do
+      ChromaWave::MockDevice.new(model: regional_model, managed_refresh: { min_interval: 0 })
+    end
+
+    it 'resets counter on display_grayscale' do
+      fb = make_framebuffer(display)
+      3.times { display.display_partial(fb) }
+      display.display_grayscale(fb)
+      expect(display.refresh_scheduler.partial_count).to eq(0)
+    end
+  end
+
+  describe 'regional refresh tracking' do
+    let(:display) do
+      ChromaWave::MockDevice.new(model: regional_model, managed_refresh: { min_interval: 0 })
+    end
+
+    it 'increments counter on display_region' do
+      fb = ChromaWave::Framebuffer.new(display.width, display.height, display.pixel_format)
+      display.display_region(fb, x: 0, y: 0, width: 8, height: 8)
+      expect(display.refresh_scheduler.partial_count).to eq(1)
+    end
+
+    context 'when past partial_limit' do
+      let(:display) do
+        ChromaWave::MockDevice.new(
+          model: regional_model,
+          managed_refresh: { partial_limit: 2, min_interval: 0 }
+        )
+      end
+
+      before do
+        fb = ChromaWave::Framebuffer.new(display.width, display.height, display.pixel_format)
+        display.display_region(fb, x: 0, y: 0, width: 8, height: 8)
+        display.clear_operations!
+        2.times { display.display_region(fb, x: 0, y: 0, width: 8, height: 8) }
+      end
+
+      it 'does not trigger auto-full-refresh' do
+        expect(display.operations(:init)).to be_empty
+      end
+
+      it 'still increments partial count' do
+        expect(display.refresh_scheduler.partial_count).to eq(3)
+      end
+    end
+  end
+
+  describe 'auto-full-refresh' do
+    let(:display) do
+      ChromaWave::MockDevice.new(
+        model: model,
+        managed_refresh: { partial_limit: 3, min_interval: 0 }
+      )
+    end
+
+    it 'triggers a full refresh when partial limit is reached' do
+      fb = make_framebuffer(display)
+
+      # First 2 partials — no auto-refresh (count goes 1, 2)
+      2.times { display.display_partial(fb) }
+      expect(display.refresh_scheduler.partial_count).to eq(2)
+
+      # 3rd partial: track_partial! → count=3, needs_full? → true, auto-refresh fires
+      display.clear_operations!
+      display.display_partial(fb)
+
+      init_ops = display.operations(:init)
+      init_modes = init_ops.map { |o| o[:mode] }
+      expect(init_modes).to include(:full)
+    end
+
+    it 'resets counter after auto-full-refresh' do
+      fb = make_framebuffer(display)
+      3.times { display.display_partial(fb) }
+
+      # 3rd call: track_partial!(count=3), auto-refresh(track_full! → count=0), super
+      expect(display.refresh_scheduler.partial_count).to eq(0)
+    end
+
+    it 'shows full init followed by partial init in operation log' do
+      fb = make_framebuffer(display)
+      3.times { display.display_partial(fb) }
+
+      init_ops = display.operations(:init)
+      init_modes = init_ops.map { |o| o[:mode] }
+
+      # 1st partial inits partial mode, 2nd reuses it (no re-init),
+      # 3rd triggers full refresh then re-inits partial for the actual display
+      expect(init_modes).to eq(%i[partial full partial])
+    end
+
+    context 'when auto_full_refresh is disabled' do
+      let(:display) do
+        ChromaWave::MockDevice.new(
+          model: model,
+          managed_refresh: { partial_limit: 3, min_interval: 0, auto_full_refresh: false }
+        )
+      end
+
+      it 'does not trigger a full refresh at the limit' do
+        fb = make_framebuffer(display)
+        5.times { display.display_partial(fb) }
+
+        init_ops = display.operations(:init)
+        init_modes = init_ops.map { |o| o[:mode] }
+        expect(init_modes).to eq([:partial])
+      end
+
+      it 'continues incrementing the partial count past the limit' do
+        fb = make_framebuffer(display)
+        5.times { display.display_partial(fb) }
+        expect(display.refresh_scheduler.partial_count).to eq(5)
+      end
+    end
+  end
+
+  describe 'auto-full-refresh with display_fast' do
+    let(:display) do
+      ChromaWave::MockDevice.new(
+        model: model,
+        managed_refresh: { partial_limit: 2, min_interval: 0 }
+      )
+    end
+
+    it 'triggers a full refresh when fast refresh hits the limit' do
+      fb = make_framebuffer(display)
+      display.display_fast(fb) # count=1
+      display.clear_operations!
+      display.display_fast(fb) # count=2 → triggers auto-refresh
+
+      init_ops = display.operations(:init)
+      init_modes = init_ops.map { |o| o[:mode] }
+      expect(init_modes).to include(:full)
+    end
+  end
+
+  describe 'interval warning' do
+    let(:display) do
+      ChromaWave::MockDevice.new(model: model, managed_refresh: { min_interval: 9999 })
+    end
+
+    it 'warns when refreshing too fast' do
+      fb = make_framebuffer(display)
+      display.display_partial(fb) # sets last_refresh_at
+
+      expect { display.display_partial(fb) }
+        .to output(/Refresh interval too short/).to_stderr
+    end
+
+    it 'warns on show after a recent refresh' do
+      fb = make_framebuffer(display)
+      display.show(fb)
+
+      expect { display.show(fb) }
+        .to output(/Refresh interval too short/).to_stderr
+    end
+
+    it 'does not warn on the first refresh' do
+      fb = make_framebuffer(display)
+
+      expect { display.display_partial(fb) }
+        .not_to output.to_stderr
+    end
+
+    context 'with min_interval: 0' do
+      let(:display) do
+        ChromaWave::MockDevice.new(model: model, managed_refresh: { min_interval: 0 })
+      end
+
+      it 'never warns' do
+        fb = make_framebuffer(display)
+        display.display_partial(fb)
+
+        expect { display.display_partial(fb) }
+          .not_to output.to_stderr
+      end
+    end
+  end
+
+  describe 'return values' do
+    let(:display) do
+      ChromaWave::MockDevice.new(model: model, managed_refresh: { min_interval: 0 })
+    end
+
+    it 'display_partial returns self' do
+      fb = make_framebuffer(display)
+      expect(display.display_partial(fb)).to eq(display)
+    end
+
+    it 'display_fast returns self' do
+      fb = make_framebuffer(display)
+      expect(display.display_fast(fb)).to eq(display)
+    end
+
+    it 'show returns self' do
+      canvas = make_canvas(display)
+      expect(display.show(canvas)).to eq(display)
+    end
+
+    it 'clear returns self' do
+      expect(display.clear).to eq(display)
+    end
+
+    it 'display_base returns self' do
+      fb = make_framebuffer(display)
+      expect(display.display_base(fb)).to eq(display)
+    end
+  end
+
+  describe 'thread safety' do
+    let(:display) do
+      ChromaWave::MockDevice.new(
+        model: model,
+        managed_refresh: { partial_limit: 1000, min_interval: 0 }
+      )
+    end
+
+    it 'handles concurrent display_partial calls without corrupting the counter' do
+      fb = make_framebuffer(display)
+      display.display_partial(fb) # warm up
+
+      threads = 10.times.map do
+        Thread.new { 10.times { display.display_partial(fb) } }
+      end
+      threads.each(&:join)
+
+      # 10 threads * 10 calls + 1 warmup = 101
+      expect(display.refresh_scheduler.partial_count).to eq(101)
+    end
+  end
+
+  describe '.open with managed_refresh' do
+    # Uses block form — no need for the shared `after { display.close }`
+    let(:display) { nil }
+
+    it 'passes managed_refresh through' do
+      ChromaWave::MockDevice.open(model: model, managed_refresh: true) do |mock|
+        expect(mock.refresh_scheduler).to be_a(ChromaWave::RefreshScheduler)
+      end
+    end
+  end
+
+  describe 'Layout handling in show' do
+    let(:display) do
+      ChromaWave::MockDevice.new(model: model, managed_refresh: { min_interval: 0 })
+    end
+
+    it 'tracks Layout show as a single full refresh (no double tracking)' do
+      layout = ChromaWave::Layout.build(width: display.width, height: display.height) {} # rubocop:disable Lint/EmptyBlock
+      display.show(layout)
+      expect(display.refresh_scheduler.partial_count).to eq(0)
+      expect(display.refresh_scheduler.last_refresh_at).not_to be_nil
+    end
+  end
+end

--- a/spec/chroma_wave/capabilities/managed_refresh_spec.rb
+++ b/spec/chroma_wave/capabilities/managed_refresh_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
         expect(display.refresh_scheduler.auto_full_refresh?).to be false
       end
     end
+
+    context 'when managed_refresh: is an invalid truthy value' do
+      it 'raises ArgumentError for a Symbol' do
+        expect { ChromaWave::MockDevice.new(model: model, managed_refresh: :defaults) }
+          .to raise_error(ArgumentError, /managed_refresh must be true or a Hash/)
+      end
+
+      it 'raises ArgumentError for a String' do
+        expect { ChromaWave::MockDevice.new(model: model, managed_refresh: 'yes') }
+          .to raise_error(ArgumentError, /managed_refresh must be true or a Hash/)
+      end
+    end
   end
 
   describe 'partial tracking' do

--- a/spec/chroma_wave/capabilities/managed_refresh_spec.rb
+++ b/spec/chroma_wave/capabilities/managed_refresh_spec.rb
@@ -342,6 +342,22 @@ RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
       fb = make_framebuffer(display)
       expect(display.display_base(fb)).to eq(display)
     end
+
+    it 'display_grayscale returns self' do
+      disp = ChromaWave::MockDevice.new(model: regional_model, managed_refresh: { min_interval: 0 })
+      fb = make_framebuffer(disp)
+      expect(disp.display_grayscale(fb)).to eq(disp)
+    ensure
+      disp&.close
+    end
+
+    it 'display_region returns self' do
+      disp = ChromaWave::MockDevice.new(model: regional_model, managed_refresh: { min_interval: 0 })
+      fb = make_framebuffer(disp)
+      expect(disp.display_region(fb, x: 0, y: 0, width: 8, height: 8)).to eq(disp)
+    ensure
+      disp&.close
+    end
   end
 
   describe 'thread safety' do
@@ -374,6 +390,45 @@ RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
       ChromaWave::MockDevice.open(model: model, managed_refresh: true) do |mock|
         expect(mock.refresh_scheduler).to be_a(ChromaWave::RefreshScheduler)
       end
+    end
+  end
+
+  describe 'error propagation preserves scheduler state' do
+    let(:display) do
+      ChromaWave::MockDevice.new(model: model, managed_refresh: { min_interval: 0 })
+    end
+
+    it 'does not increment partial count when display_partial raises' do
+      fb = make_framebuffer(display)
+      display.display_partial(fb) # warm up, count=1
+
+      device_stub = display.send(:device)
+      allow(device_stub).to receive(:_epd_display).and_raise(ChromaWave::DeviceError, 'simulated failure')
+
+      expect { display.display_partial(fb) }.to raise_error(ChromaWave::DeviceError)
+      expect(display.refresh_scheduler.partial_count).to eq(1)
+    end
+
+    it 'does not reset partial count when show raises' do
+      fb = make_framebuffer(display)
+      3.times { display.display_partial(fb) }
+
+      device_stub = display.send(:device)
+      allow(device_stub).to receive(:_epd_display).and_raise(ChromaWave::DeviceError, 'simulated failure')
+
+      expect { display.show(fb) }.to raise_error(ChromaWave::DeviceError)
+      expect(display.refresh_scheduler.partial_count).to eq(3)
+    end
+
+    it 'does not reset partial count when clear raises' do
+      fb = make_framebuffer(display)
+      3.times { display.display_partial(fb) }
+
+      device_stub = display.send(:device)
+      allow(device_stub).to receive(:_epd_clear).and_raise(ChromaWave::DeviceError, 'simulated failure')
+
+      expect { display.clear }.to raise_error(ChromaWave::DeviceError)
+      expect(display.refresh_scheduler.partial_count).to eq(3)
     end
   end
 

--- a/spec/chroma_wave/capabilities/managed_refresh_spec.rb
+++ b/spec/chroma_wave/capabilities/managed_refresh_spec.rb
@@ -271,6 +271,38 @@ RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
     end
   end
 
+  describe 'auto-full-refresh failure resilience' do
+    let(:display) do
+      ChromaWave::MockDevice.new(
+        model: model,
+        managed_refresh: { partial_limit: 2, min_interval: 0 }
+      )
+    end
+
+    it 'warns and resets counter when force_full_refresh! fails' do
+      fb = make_framebuffer(display)
+      display.display_partial(fb) # count=1
+
+      # Stub force_full_refresh! to simulate hardware failure during auto-refresh
+      allow(display).to receive(:force_full_refresh!)
+        .and_raise(ChromaWave::DeviceError, 'hardware fault')
+
+      expect { display.display_partial(fb) } # count=2 → triggers auto-refresh → fails
+        .to output(/Auto-full-refresh failed/).to_stderr
+      expect(display.refresh_scheduler.partial_count).to eq(0)
+    end
+
+    it 'does not raise to the caller when auto-refresh fails' do
+      fb = make_framebuffer(display)
+      display.display_partial(fb) # count=1
+
+      allow(display).to receive(:force_full_refresh!)
+        .and_raise(ChromaWave::DeviceError, 'hardware fault')
+
+      expect { display.display_partial(fb) }.not_to raise_error
+    end
+  end
+
   describe 'interval warning' do
     let(:display) do
       ChromaWave::MockDevice.new(model: model, managed_refresh: { min_interval: 9999 })

--- a/spec/chroma_wave/capabilities/managed_refresh_spec.rb
+++ b/spec/chroma_wave/capabilities/managed_refresh_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe ChromaWave::Capabilities::ManagedRefresh do
           .to raise_error(ArgumentError, /managed_refresh must be true or a Hash/)
       end
     end
+
+    context 'when managed_refresh is set on a COLOR4 display' do
+      it 'raises ArgumentError' do
+        expect { ChromaWave::MockDevice.new(model: :epd_2in9b_v4, managed_refresh: true) }
+          .to raise_error(ArgumentError, /COLOR4/)
+      end
+    end
   end
 
   describe 'partial tracking' do

--- a/spec/chroma_wave/refresh_scheduler_spec.rb
+++ b/spec/chroma_wave/refresh_scheduler_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+RSpec.describe ChromaWave::RefreshScheduler do
+  describe '#initialize' do
+    it 'uses default values' do
+      scheduler = described_class.new
+      expect(scheduler.partial_limit).to eq(5)
+      expect(scheduler.min_interval).to eq(180)
+      expect(scheduler.auto_full_refresh?).to be true
+      expect(scheduler.partial_count).to eq(0)
+      expect(scheduler.last_refresh_at).to be_nil
+    end
+
+    it 'accepts custom partial_limit' do
+      scheduler = described_class.new(partial_limit: 10)
+      expect(scheduler.partial_limit).to eq(10)
+    end
+
+    it 'accepts custom min_interval' do
+      scheduler = described_class.new(min_interval: 60)
+      expect(scheduler.min_interval).to eq(60)
+    end
+
+    it 'accepts auto_full_refresh: false' do
+      scheduler = described_class.new(auto_full_refresh: false)
+      expect(scheduler.auto_full_refresh?).to be false
+    end
+  end
+
+  describe '#track_partial!' do
+    it 'increments the partial count' do
+      scheduler = described_class.new
+      expect { scheduler.track_partial! }
+        .to change(scheduler, :partial_count).from(0).to(1)
+    end
+
+    it 'accumulates across multiple calls' do
+      scheduler = described_class.new
+      3.times { scheduler.track_partial! }
+      expect(scheduler.partial_count).to eq(3)
+    end
+
+    it 'sets last_refresh_at' do
+      scheduler = described_class.new
+      expect(scheduler.last_refresh_at).to be_nil
+      scheduler.track_partial!
+      expect(scheduler.last_refresh_at).to be_a(Float)
+    end
+  end
+
+  describe '#track_full!' do
+    it 'resets the partial count to zero' do
+      scheduler = described_class.new
+      3.times { scheduler.track_partial! }
+      expect { scheduler.track_full! }
+        .to change(scheduler, :partial_count).from(3).to(0)
+    end
+
+    it 'sets last_refresh_at' do
+      scheduler = described_class.new
+      scheduler.track_full!
+      expect(scheduler.last_refresh_at).to be_a(Float)
+    end
+
+    it 'updates last_refresh_at on subsequent calls' do
+      scheduler = described_class.new
+      scheduler.track_full!
+      first_time = scheduler.last_refresh_at
+      scheduler.track_full!
+      expect(scheduler.last_refresh_at).to be >= first_time
+    end
+  end
+
+  describe '#needs_full?' do
+    it 'returns false when count is below limit' do
+      scheduler = described_class.new(partial_limit: 5)
+      4.times { scheduler.track_partial! }
+      expect(scheduler.needs_full?).to be false
+    end
+
+    it 'returns true when count equals limit' do
+      scheduler = described_class.new(partial_limit: 5)
+      5.times { scheduler.track_partial! }
+      expect(scheduler.needs_full?).to be true
+    end
+
+    it 'returns true when count exceeds limit' do
+      scheduler = described_class.new(partial_limit: 5)
+      6.times { scheduler.track_partial! }
+      expect(scheduler.needs_full?).to be true
+    end
+
+    it 'returns false after a full refresh resets the count' do
+      scheduler = described_class.new(partial_limit: 5)
+      5.times { scheduler.track_partial! }
+      scheduler.track_full!
+      expect(scheduler.needs_full?).to be false
+    end
+  end
+
+  describe '#check_interval!' do
+    it 'does not warn on the first refresh (last_refresh_at is nil)' do
+      scheduler = described_class.new(min_interval: 9999)
+      expect { scheduler.check_interval! }.not_to output.to_stderr
+    end
+
+    it 'warns when elapsed time is less than min_interval' do
+      scheduler = described_class.new(min_interval: 9999)
+      scheduler.track_partial!
+      expect { scheduler.check_interval! }
+        .to output(/Refresh interval too short/).to_stderr
+    end
+
+    it 'includes elapsed and minimum times in the warning' do
+      scheduler = described_class.new(min_interval: 9999)
+      scheduler.track_partial!
+      expect { scheduler.check_interval! }
+        .to output(/< 9999s minimum/).to_stderr
+    end
+
+    it 'does not warn when min_interval is 0' do
+      scheduler = described_class.new(min_interval: 0)
+      scheduler.track_partial!
+      expect { scheduler.check_interval! }.not_to output.to_stderr
+    end
+  end
+
+  describe '#auto_full_refresh?' do
+    it 'returns true by default' do
+      expect(described_class.new.auto_full_refresh?).to be true
+    end
+
+    it 'returns false when disabled' do
+      expect(described_class.new(auto_full_refresh: false).auto_full_refresh?).to be false
+    end
+  end
+
+  describe '#reset!' do
+    it 'resets partial count to zero' do
+      scheduler = described_class.new
+      3.times { scheduler.track_partial! }
+      expect { scheduler.reset! }
+        .to change(scheduler, :partial_count).from(3).to(0)
+    end
+
+    it 'does not change last_refresh_at' do
+      scheduler = described_class.new
+      scheduler.track_partial!
+      timestamp = scheduler.last_refresh_at
+      scheduler.reset!
+      expect(scheduler.last_refresh_at).to eq(timestamp)
+    end
+  end
+
+  describe 'edge cases' do
+    it 'handles partial_limit of 0 (needs_full? always true)' do
+      scheduler = described_class.new(partial_limit: 0)
+      expect(scheduler.needs_full?).to be true
+    end
+
+    it 'handles partial_limit of 1 (needs_full? after first partial)' do
+      scheduler = described_class.new(partial_limit: 1)
+      expect(scheduler.needs_full?).to be false
+      scheduler.track_partial!
+      expect(scheduler.needs_full?).to be true
+    end
+  end
+end

--- a/spec/chroma_wave/refresh_scheduler_spec.rb
+++ b/spec/chroma_wave/refresh_scheduler_spec.rb
@@ -152,17 +152,31 @@ RSpec.describe ChromaWave::RefreshScheduler do
     end
   end
 
-  describe 'edge cases' do
-    it 'handles partial_limit of 0 (needs_full? always true)' do
-      scheduler = described_class.new(partial_limit: 0)
-      expect(scheduler.needs_full?).to be true
+  describe 'input validation' do
+    it 'raises ArgumentError for partial_limit: 0' do
+      expect { described_class.new(partial_limit: 0) }
+        .to raise_error(ArgumentError, /partial_limit must be >= 1/)
     end
 
-    it 'handles partial_limit of 1 (needs_full? after first partial)' do
+    it 'raises ArgumentError for negative partial_limit' do
+      expect { described_class.new(partial_limit: -1) }
+        .to raise_error(ArgumentError, /partial_limit must be >= 1/)
+    end
+
+    it 'raises ArgumentError for negative min_interval' do
+      expect { described_class.new(min_interval: -5) }
+        .to raise_error(ArgumentError, /min_interval must be >= 0/)
+    end
+
+    it 'accepts partial_limit: 1' do
       scheduler = described_class.new(partial_limit: 1)
       expect(scheduler.needs_full?).to be false
       scheduler.track_partial!
       expect(scheduler.needs_full?).to be true
+    end
+
+    it 'accepts min_interval: 0' do
+      expect { described_class.new(min_interval: 0) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds opt-in automatic refresh scheduling for e-paper displays. E-paper panels accumulate ghosting artifacts after repeated partial refreshes — Waveshare recommends periodic full refreshes to clear this. ManagedRefresh automates that maintenance cycle, tracking partial refresh counts and triggering full refreshes when a configurable limit is reached. Also warns on rapid-fire updates that could damage the display.

## Changes

- **`RefreshScheduler`** (`lib/chroma_wave/refresh_scheduler.rb`): Pure data/logic class tracking partial refresh counts, enforcing minimum intervals between refreshes, and signaling when a maintenance full refresh is due. Uses monotonic clock for interval measurement. Validates `partial_limit >= 1` and `min_interval >= 0`.
- **`Capabilities::ManagedRefresh`** (`lib/chroma_wave/capabilities/managed_refresh.rb`): Opt-in capability module that wraps 7 display methods with automatic refresh tracking. Applied via `extend` on individual instances to avoid polluting the class hierarchy. Partial trackers (`display_partial`, `display_fast`, `display_region`) increment the counter; full trackers (`show`, `display_base`, `display_grayscale`, `clear`) reset it. Auto-full-refresh is resilient to hardware failures (rescues `DeviceError`, warns, resets counter).
- **`Display`** (`lib/chroma_wave/display.rb`): Added `managed_refresh:` keyword to `.new`, `.open`, and `#initialize`. Added `setup_managed_refresh!` and `force_full_refresh!` private methods.
- **`Registry`** (`lib/chroma_wave/registry.rb`): Passes `managed_refresh:` through to Display construction.
- **`MockDevice`** (`lib/chroma_wave/mock_device.rb`): Passes `managed_refresh:` through to `.new` and `.open`.
- **`Device`** (`lib/chroma_wave/device.rb`): Switched from `Mutex` to `Monitor` for reentrant locking, required by auto-full-refresh calling `force_full_refresh!` while already holding the device lock.

## Type of Change

- [x] `feat:` New feature (ManagedRefresh capability, RefreshScheduler)
- [x] `refactor:` Mutex → Monitor, DRY wrapper extraction
- [x] `test:` 70 new specs across 2 spec files

## Testing

- **70 new examples** across `refresh_scheduler_spec.rb` (27) and `managed_refresh_spec.rb` (43)
- Full suite: **1390 examples, 0 failures**, 6 pending (unrelated gray4 model stubs)
- Coverage: 96.16% line, 88.05% branch
- Rubocop: 0 offenses
- Test scenarios covered:
  - Opt-in behavior (off by default, `true` for defaults, Hash for custom options)
  - Partial tracking across `display_partial`, `display_fast`, `display_region`
  - Full reset tracking across `show`, `clear`, `display_base`, `display_grayscale`
  - Auto-full-refresh trigger and counter reset at configurable limit
  - Auto-full-refresh disabled mode (counter keeps incrementing)
  - Auto-full-refresh hardware failure resilience (rescue, warn, reset)
  - Regional refresh skipping auto-full-refresh
  - Interval warnings (too-fast detection, no-op on first refresh, `min_interval: 0`)
  - Input validation (`partial_limit < 1`, negative `min_interval`)
  - Error propagation preserving scheduler state (partial, show, clear)
  - Layout double-tracking prevention
  - Thread safety (10 threads × 10 concurrent partial calls)
  - Return value consistency (`self` for all 7 wrapped methods)
  - `.open` block form passthrough

## Notes for Reviewers

- `ManagedRefresh` uses `extend` (not `include`) so it only affects the specific instance that opts in. This is intentional — most users won't want managed refresh, and capability modules applied at the class level via `Registry` should remain unaffected.
- The `Device` switch from `Mutex` to `Monitor` is a prerequisite: `_auto_full_refresh!` calls `force_full_refresh!` which calls device methods, while already inside `synchronize_device`. A non-reentrant `Mutex` would deadlock.
- `display_region` intentionally skips auto-full-refresh because regional updates can't safely trigger a full-screen refresh without mode re-initialization and a complete framebuffer push.
- `_auto_full_refresh!` rescues `DeviceError` and resets the counter to avoid an infinite retry loop where every subsequent partial call attempts (and fails) the maintenance refresh.

## How this Makes You Feel

### 🔄⚡🛡️📊✨