### PR TITLE
feat: Add dirty region tracking for incremental display refresh

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,7 +100,7 @@ Metrics/ModuleLength:
 # and dirty region tracking. Display adds show_dirty and mode helpers.
 # MockDevice embeds a ~120-line DeviceStub inner class that inflates the count.
 Metrics/ClassLength:
-  Max: 220
+  Max: 190
   Exclude:
     - 'lib/chroma_wave/mock_device.rb'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,10 +96,11 @@ Metrics/ModuleLength:
   Max: 500
 
 # Canvas wraps a single String buffer with RGBA operations, plus
-# optimized fill_rect, equality, inspect, and C-accelerated render_glyph.
+# optimized fill_rect, equality, inspect, C-accelerated render_glyph,
+# and dirty region tracking. Display adds show_dirty and mode helpers.
 # MockDevice embeds a ~120-line DeviceStub inner class that inflates the count.
 Metrics/ClassLength:
-  Max: 150
+  Max: 220
   Exclude:
     - 'lib/chroma_wave/mock_device.rb'
 

--- a/lib/chroma_wave.rb
+++ b/lib/chroma_wave.rb
@@ -15,6 +15,7 @@ require_relative 'chroma_wave/color'        # Color before Palette (NAME_MAP)
 require_relative 'chroma_wave/palette'      # Palette before PixelFormat (constants)
 require_relative 'chroma_wave/pixel_format' # PixelFormat before Framebuffer wrapper
 require_relative 'chroma_wave/pen'          # Pen before Surface (used by Drawing::Primitives)
+require_relative 'chroma_wave/rect'         # Rect value type (used by dirty region tracking)
 require_relative 'chroma_wave/surface'      # Surface before Framebuffer (included by FB)
 require_relative 'chroma_wave/framebuffer'  # Reopens C class, prepends bridge, includes Surface
 require_relative 'chroma_wave/canvas'       # RGBA pixel buffer, includes Surface

--- a/lib/chroma_wave.rb
+++ b/lib/chroma_wave.rb
@@ -16,6 +16,7 @@ require_relative 'chroma_wave/palette'      # Palette before PixelFormat (consta
 require_relative 'chroma_wave/pixel_format' # PixelFormat before Framebuffer wrapper
 require_relative 'chroma_wave/pen'          # Pen before Surface (used by Drawing::Primitives)
 require_relative 'chroma_wave/rect'         # Rect value type (used by dirty region tracking)
+require_relative 'chroma_wave/dirty_tracking' # DirtyTracking mixin (included by Canvas)
 require_relative 'chroma_wave/surface'      # Surface before Framebuffer (included by FB)
 require_relative 'chroma_wave/framebuffer'  # Reopens C class, prepends bridge, includes Surface
 require_relative 'chroma_wave/canvas'       # RGBA pixel buffer, includes Surface

--- a/lib/chroma_wave/canvas.rb
+++ b/lib/chroma_wave/canvas.rb
@@ -35,6 +35,49 @@ module ChromaWave
       @buffer = (background.to_rgba_bytes * (width * height)).b
     end
 
+    # Returns true if the canvas has been modified since the last {#clean!}.
+    #
+    # @return [Boolean]
+    def dirty?
+      !@dirty_x.nil?
+    end
+
+    # Returns the bounding box of all modifications since the last {#clean!}.
+    #
+    # @return [Hash{Symbol => Integer}, nil] +{x:, y:, width:, height:}+ or nil if clean
+    def dirty_region
+      return nil unless @dirty_x
+
+      { x: @dirty_x, y: @dirty_y, width: @dirty_w, height: @dirty_h }
+    end
+
+    # Resets dirty tracking, marking the canvas as clean.
+    #
+    # @return [self]
+    def clean!
+      @dirty_x = @dirty_y = @dirty_w = @dirty_h = nil
+      self
+    end
+
+    # Explicitly marks a rectangular region as dirty.
+    #
+    # Accepts either a {Rect} or keyword arguments.
+    #
+    # @param rect [Rect, nil] a Rect to mark dirty
+    # @param x [Integer, nil] left edge
+    # @param y [Integer, nil] top edge
+    # @param width [Integer, nil] width
+    # @param height [Integer, nil] height
+    # @return [self]
+    def mark_dirty(rect = nil, x: nil, y: nil, width: nil, height: nil)
+      if rect
+        expand_dirty(rect.x, rect.y, rect.width, rect.height)
+      else
+        expand_dirty(x, y, width, height)
+      end
+      self
+    end
+
     # Sets the pixel at (x, y) to the given color.
     #
     # Out-of-bounds coordinates are silently ignored.
@@ -47,6 +90,7 @@ module ChromaWave
       return self unless in_bounds?(x, y)
 
       buffer[pixel_offset(x, y), BYTES_PER_PIXEL] = color.to_rgba_bytes
+      expand_dirty(x, y, 1, 1)
       self
     end
 
@@ -73,6 +117,7 @@ module ChromaWave
       else
         clear_ruby(color)
       end
+      expand_dirty(0, 0, width, height)
       self
     end
 
@@ -100,6 +145,7 @@ module ChromaWave
       else
         blit_ruby(source, x, y)
       end
+      mark_clipped_dirty(x, y, source.width, source.height)
       self
     end
 
@@ -119,6 +165,7 @@ module ChromaWave
       else
         load_rgba_bytes_ruby(bytes, width, height, x, y)
       end
+      mark_clipped_dirty(x, y, width, height)
       self
     end
 
@@ -195,6 +242,7 @@ module ChromaWave
       _canvas_blit_glyph(buffer, bitmap, x, y, width, height,
                          self.width, self.height,
                          color.r, color.g, color.b)
+      expand_dirty(x, y, width, height)
       true
     end
 
@@ -240,18 +288,75 @@ module ChromaWave
         offset = pixel_offset(x0, row_y)
         buffer[offset, row.bytesize] = row
       end
+
+      expand_dirty(x0, y0, x1 - x0, y1 - y0)
     end
 
     private
 
     attr_reader :buffer
 
-    # Deep-copies the pixel buffer so dup/clone get independent data.
+    # Deep-copies the pixel buffer and dirty state so dup/clone get independent data.
     #
     # @param source [Canvas] the canvas being copied
     def initialize_copy(source)
       super
       @buffer = source.raw_buffer.dup
+      region = source.dirty_region
+      if region
+        @dirty_x = region[:x]
+        @dirty_y = region[:y]
+        @dirty_w = region[:width]
+        @dirty_h = region[:height]
+      else
+        @dirty_x = @dirty_y = @dirty_w = @dirty_h = nil
+      end
+    end
+
+    # Clips a rectangle to canvas bounds and marks it dirty.
+    #
+    # Used by +blit+ and +load_rgba_bytes+ where the source rect may
+    # extend beyond canvas boundaries.
+    #
+    # @param src_x [Integer] left edge of the source rect
+    # @param src_y [Integer] top edge of the source rect
+    # @param src_w [Integer] width of the source rect
+    # @param src_h [Integer] height of the source rect
+    # @return [void]
+    def mark_clipped_dirty(src_x, src_y, src_w, src_h)
+      cx = [src_x, 0].max
+      cy = [src_y, 0].max
+      cw = [src_x + src_w, width].min - cx
+      ch = [src_y + src_h, height].min - cy
+      expand_dirty(cx, cy, cw, ch) if cw.positive? && ch.positive?
+    end
+
+    # Expands the dirty bounding box to include the given rectangle.
+    #
+    # Uses ternary operators instead of +[a, b].min/max+ to avoid
+    # Array allocations on the hot path (called per-pixel in +set_pixel+).
+    #
+    # @param new_x [Integer] left edge of the new dirty area
+    # @param new_y [Integer] top edge of the new dirty area
+    # @param new_w [Integer] width of the new dirty area
+    # @param new_h [Integer] height of the new dirty area
+    # @return [void]
+    def expand_dirty(new_x, new_y, new_w, new_h)
+      if @dirty_x
+        right = new_x + new_w
+        bottom = new_y + new_h
+        old_right = @dirty_x + @dirty_w
+        old_bottom = @dirty_y + @dirty_h
+        @dirty_x = new_x < @dirty_x ? new_x : @dirty_x     # rubocop:disable Style/MinMaxComparison
+        @dirty_y = new_y < @dirty_y ? new_y : @dirty_y     # rubocop:disable Style/MinMaxComparison
+        @dirty_w = (right > old_right ? right : old_right) - @dirty_x     # rubocop:disable Style/MinMaxComparison
+        @dirty_h = (bottom > old_bottom ? bottom : old_bottom) - @dirty_y # rubocop:disable Style/MinMaxComparison
+      else
+        @dirty_x = new_x
+        @dirty_y = new_y
+        @dirty_w = new_w
+        @dirty_h = new_h
+      end
     end
 
     # Byte offset for pixel (x, y) in the RGBA buffer.
@@ -264,11 +369,14 @@ module ChromaWave
     # Falls back to the pure-Ruby path when the C method is unavailable.
     def render_glyph(glyph, base_x, base_y, color)
       if respond_to?(:_canvas_blit_glyph, true)
+        gx = base_x + glyph[:x]
+        gy = base_y + glyph[:y]
         _canvas_blit_glyph(buffer, glyph[:bitmap],
-                           base_x + glyph[:x], base_y + glyph[:y],
+                           gx, gy,
                            glyph[:width], glyph[:height],
                            width, height,
                            color.r, color.g, color.b)
+        expand_dirty(gx, gy, glyph[:width], glyph[:height])
       else
         super
       end

--- a/lib/chroma_wave/canvas.rb
+++ b/lib/chroma_wave/canvas.rb
@@ -200,7 +200,7 @@ module ChromaWave
       _canvas_blit_glyph(buffer, bitmap, x, y, width, height,
                          self.width, self.height,
                          color.r, color.g, color.b)
-      expand_dirty(x, y, width, height)
+      mark_clipped_dirty(x, y, width, height)
       true
     end
 
@@ -280,7 +280,7 @@ module ChromaWave
                            glyph[:width], glyph[:height],
                            width, height,
                            color.r, color.g, color.b)
-        expand_dirty(gx, gy, glyph[:width], glyph[:height])
+        mark_clipped_dirty(gx, gy, glyph[:width], glyph[:height])
       else
         super
       end

--- a/lib/chroma_wave/canvas.rb
+++ b/lib/chroma_wave/canvas.rb
@@ -16,6 +16,7 @@ module ChromaWave
   #   canvas.clear(Color::BLACK)
   class Canvas
     include Surface
+    include DirtyTracking
 
     # Bytes per pixel in the RGBA buffer.
     BYTES_PER_PIXEL = 4
@@ -33,53 +34,6 @@ module ChromaWave
       @width  = width
       @height = height
       @buffer = (background.to_rgba_bytes * (width * height)).b
-    end
-
-    # Returns true if the canvas has been modified since the last {#clean!}.
-    #
-    # @return [Boolean]
-    def dirty?
-      !@dirty_x.nil?
-    end
-
-    # Returns the bounding box of all modifications since the last {#clean!}.
-    #
-    # @return [Rect, nil] the dirty bounding box or nil if clean
-    def dirty_region
-      return nil unless @dirty_x
-
-      Rect.new(x: @dirty_x, y: @dirty_y, width: @dirty_w, height: @dirty_h)
-    end
-
-    # Resets dirty tracking, marking the canvas as clean.
-    #
-    # @return [self]
-    def clean!
-      @dirty_x = @dirty_y = @dirty_w = @dirty_h = nil
-      self
-    end
-
-    # Explicitly marks a rectangular region as dirty.
-    #
-    # Accepts either a {Rect} or keyword arguments.
-    #
-    # @param rect [Rect, nil] a Rect to mark dirty
-    # @param x [Integer, nil] left edge
-    # @param y [Integer, nil] top edge
-    # @param width [Integer, nil] width
-    # @param height [Integer, nil] height
-    # @return [self]
-    def mark_dirty(rect = nil, x: nil, y: nil, width: nil, height: nil)
-      if rect
-        expand_dirty(rect.x, rect.y, rect.width, rect.height)
-      else
-        unless x && y && width && height
-          raise ArgumentError, 'mark_dirty requires a Rect or x:, y:, width:, height: keywords'
-        end
-
-        expand_dirty(x, y, width, height)
-      end
-      self
     end
 
     # Sets the pixel at (x, y) to the given color.
@@ -306,64 +260,8 @@ module ChromaWave
     def initialize_copy(source)
       super
       @buffer = source.raw_buffer.dup
-      region = source.dirty_region
-      if region
-        @dirty_x = region.x
-        @dirty_y = region.y
-        @dirty_w = region.width
-        @dirty_h = region.height
-      else
-        @dirty_x = @dirty_y = @dirty_w = @dirty_h = nil
-      end
+      copy_dirty_state(source)
     end
-
-    # Clips a rectangle to canvas bounds and marks it dirty.
-    #
-    # Used by +blit+ and +load_rgba_bytes+ where the source rect may
-    # extend beyond canvas boundaries.
-    #
-    # @param src_x [Integer] left edge of the source rect
-    # @param src_y [Integer] top edge of the source rect
-    # @param src_w [Integer] width of the source rect
-    # @param src_h [Integer] height of the source rect
-    # @return [void]
-    def mark_clipped_dirty(src_x, src_y, src_w, src_h)
-      cx = [src_x, 0].max
-      cy = [src_y, 0].max
-      cw = [src_x + src_w, width].min - cx
-      ch = [src_y + src_h, height].min - cy
-      expand_dirty(cx, cy, cw, ch) if cw.positive? && ch.positive?
-    end
-
-    # Expands the dirty bounding box to include the given rectangle.
-    #
-    # Uses ternary operators instead of +[a, b].min/max+ to avoid
-    # Array allocations on the hot path (called per-pixel in +set_pixel+).
-    #
-    # @param new_x [Integer] left edge of the new dirty area
-    # @param new_y [Integer] top edge of the new dirty area
-    # @param new_w [Integer] width of the new dirty area
-    # @param new_h [Integer] height of the new dirty area
-    # @return [void]
-    # rubocop:disable Style/MinMaxComparison -- ternaries avoid Array allocs on hot path
-    def expand_dirty(new_x, new_y, new_w, new_h)
-      if @dirty_x
-        right = new_x + new_w
-        bottom = new_y + new_h
-        old_right = @dirty_x + @dirty_w
-        old_bottom = @dirty_y + @dirty_h
-        @dirty_x = new_x < @dirty_x ? new_x : @dirty_x
-        @dirty_y = new_y < @dirty_y ? new_y : @dirty_y
-        @dirty_w = (right > old_right ? right : old_right) - @dirty_x
-        @dirty_h = (bottom > old_bottom ? bottom : old_bottom) - @dirty_y
-      else
-        @dirty_x = new_x
-        @dirty_y = new_y
-        @dirty_w = new_w
-        @dirty_h = new_h
-      end
-    end
-    # rubocop:enable Style/MinMaxComparison
 
     # Byte offset for pixel (x, y) in the RGBA buffer.
     def pixel_offset(x, y)

--- a/lib/chroma_wave/canvas.rb
+++ b/lib/chroma_wave/canvas.rb
@@ -44,11 +44,11 @@ module ChromaWave
 
     # Returns the bounding box of all modifications since the last {#clean!}.
     #
-    # @return [Hash{Symbol => Integer}, nil] +{x:, y:, width:, height:}+ or nil if clean
+    # @return [Rect, nil] the dirty bounding box or nil if clean
     def dirty_region
       return nil unless @dirty_x
 
-      { x: @dirty_x, y: @dirty_y, width: @dirty_w, height: @dirty_h }
+      Rect.new(x: @dirty_x, y: @dirty_y, width: @dirty_w, height: @dirty_h)
     end
 
     # Resets dirty tracking, marking the canvas as clean.
@@ -73,6 +73,10 @@ module ChromaWave
       if rect
         expand_dirty(rect.x, rect.y, rect.width, rect.height)
       else
+        unless x && y && width && height
+          raise ArgumentError, 'mark_dirty requires a Rect or x:, y:, width:, height: keywords'
+        end
+
         expand_dirty(x, y, width, height)
       end
       self
@@ -304,10 +308,10 @@ module ChromaWave
       @buffer = source.raw_buffer.dup
       region = source.dirty_region
       if region
-        @dirty_x = region[:x]
-        @dirty_y = region[:y]
-        @dirty_w = region[:width]
-        @dirty_h = region[:height]
+        @dirty_x = region.x
+        @dirty_y = region.y
+        @dirty_w = region.width
+        @dirty_h = region.height
       else
         @dirty_x = @dirty_y = @dirty_w = @dirty_h = nil
       end
@@ -341,16 +345,17 @@ module ChromaWave
     # @param new_w [Integer] width of the new dirty area
     # @param new_h [Integer] height of the new dirty area
     # @return [void]
+    # rubocop:disable Style/MinMaxComparison -- ternaries avoid Array allocs on hot path
     def expand_dirty(new_x, new_y, new_w, new_h)
       if @dirty_x
         right = new_x + new_w
         bottom = new_y + new_h
         old_right = @dirty_x + @dirty_w
         old_bottom = @dirty_y + @dirty_h
-        @dirty_x = new_x < @dirty_x ? new_x : @dirty_x     # rubocop:disable Style/MinMaxComparison
-        @dirty_y = new_y < @dirty_y ? new_y : @dirty_y     # rubocop:disable Style/MinMaxComparison
-        @dirty_w = (right > old_right ? right : old_right) - @dirty_x     # rubocop:disable Style/MinMaxComparison
-        @dirty_h = (bottom > old_bottom ? bottom : old_bottom) - @dirty_y # rubocop:disable Style/MinMaxComparison
+        @dirty_x = new_x < @dirty_x ? new_x : @dirty_x
+        @dirty_y = new_y < @dirty_y ? new_y : @dirty_y
+        @dirty_w = (right > old_right ? right : old_right) - @dirty_x
+        @dirty_h = (bottom > old_bottom ? bottom : old_bottom) - @dirty_y
       else
         @dirty_x = new_x
         @dirty_y = new_y
@@ -358,6 +363,7 @@ module ChromaWave
         @dirty_h = new_h
       end
     end
+    # rubocop:enable Style/MinMaxComparison
 
     # Byte offset for pixel (x, y) in the RGBA buffer.
     def pixel_offset(x, y)

--- a/lib/chroma_wave/dirty_tracking.rb
+++ b/lib/chroma_wave/dirty_tracking.rb
@@ -50,13 +50,13 @@ module ChromaWave
     # @return [self]
     def mark_dirty(rect = nil, x: nil, y: nil, width: nil, height: nil)
       if rect
-        expand_dirty(rect.x, rect.y, rect.width, rect.height)
+        mark_clipped_dirty(rect.x, rect.y, rect.width, rect.height)
       else
         unless x && y && width && height
           raise ArgumentError, 'mark_dirty requires a Rect or x:, y:, width:, height: keywords'
         end
 
-        expand_dirty(x, y, width, height)
+        mark_clipped_dirty(x, y, width, height)
       end
       self
     end

--- a/lib/chroma_wave/dirty_tracking.rb
+++ b/lib/chroma_wave/dirty_tracking.rb
@@ -127,10 +127,12 @@ module ChromaWave
         bottom = new_y + new_h
         old_right = dirty_x + dirty_w
         old_bottom = dirty_y + dirty_h
-        @dirty_x = new_x < dirty_x ? new_x : dirty_x
-        @dirty_y = new_y < dirty_y ? new_y : dirty_y
-        @dirty_w = (right > old_right ? right : old_right) - dirty_x
-        @dirty_h = (bottom > old_bottom ? bottom : old_bottom) - dirty_y
+        min_x = new_x < dirty_x ? new_x : dirty_x
+        min_y = new_y < dirty_y ? new_y : dirty_y
+        @dirty_x = min_x
+        @dirty_y = min_y
+        @dirty_w = (right > old_right ? right : old_right) - min_x
+        @dirty_h = (bottom > old_bottom ? bottom : old_bottom) - min_y
       else
         @dirty_x = new_x
         @dirty_y = new_y

--- a/lib/chroma_wave/dirty_tracking.rb
+++ b/lib/chroma_wave/dirty_tracking.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module ChromaWave
+  # Mixin for bounding-box dirty region tracking.
+  #
+  # Tracks a single axis-aligned bounding box that expands as regions are
+  # marked dirty. Designed for inclusion in any class that provides +width+
+  # and +height+ methods (the Surface protocol).
+  #
+  # @example
+  #   class MyCanvas
+  #     include DirtyTracking
+  #     attr_reader :width, :height
+  #     # ...
+  #   end
+  module DirtyTracking
+    # Returns true if any region has been marked dirty since the last {#clean!}.
+    #
+    # @return [Boolean]
+    def dirty?
+      !@dirty_x.nil?
+    end
+
+    # Returns the bounding box of all modifications since the last {#clean!}.
+    #
+    # @return [Rect, nil] the dirty bounding box or nil if clean
+    def dirty_region
+      return nil unless @dirty_x
+
+      Rect.new(x: @dirty_x, y: @dirty_y, width: @dirty_w, height: @dirty_h)
+    end
+
+    # Resets dirty tracking, marking the surface as clean.
+    #
+    # @return [self]
+    def clean!
+      @dirty_x = @dirty_y = @dirty_w = @dirty_h = nil
+      self
+    end
+
+    # Explicitly marks a rectangular region as dirty.
+    #
+    # Accepts either a {Rect} or keyword arguments.
+    #
+    # @param rect [Rect, nil] a Rect to mark dirty
+    # @param x [Integer, nil] left edge
+    # @param y [Integer, nil] top edge
+    # @param width [Integer, nil] width
+    # @param height [Integer, nil] height
+    # @return [self]
+    def mark_dirty(rect = nil, x: nil, y: nil, width: nil, height: nil)
+      if rect
+        expand_dirty(rect.x, rect.y, rect.width, rect.height)
+      else
+        unless x && y && width && height
+          raise ArgumentError, 'mark_dirty requires a Rect or x:, y:, width:, height: keywords'
+        end
+
+        expand_dirty(x, y, width, height)
+      end
+      self
+    end
+
+    private
+
+    # Copies dirty state from +source+ into this instance.
+    #
+    # Intended for use in +initialize_copy+ to deep-copy dirty tracking
+    # state when duplicating or cloning the includer.
+    #
+    # @param source [DirtyTracking] the source to copy dirty state from
+    # @return [void]
+    def copy_dirty_state(source)
+      region = source.dirty_region
+      if region
+        @dirty_x = region.x
+        @dirty_y = region.y
+        @dirty_w = region.width
+        @dirty_h = region.height
+      else
+        @dirty_x = @dirty_y = @dirty_w = @dirty_h = nil
+      end
+    end
+
+    # Clips a rectangle to surface bounds and marks it dirty.
+    #
+    # Used by operations where the source rect may extend beyond surface
+    # boundaries (e.g. +blit+, +load_rgba_bytes+).
+    #
+    # @param src_x [Integer] left edge of the source rect
+    # @param src_y [Integer] top edge of the source rect
+    # @param src_w [Integer] width of the source rect
+    # @param src_h [Integer] height of the source rect
+    # @return [void]
+    def mark_clipped_dirty(src_x, src_y, src_w, src_h)
+      cx = [src_x, 0].max
+      cy = [src_y, 0].max
+      cw = [src_x + src_w, width].min - cx
+      ch = [src_y + src_h, height].min - cy
+      expand_dirty(cx, cy, cw, ch) if cw.positive? && ch.positive?
+    end
+
+    # Expands the dirty bounding box to include the given rectangle.
+    #
+    # Uses ternary operators instead of +[a, b].min/max+ to avoid
+    # Array allocations on the hot path (called per-pixel in +set_pixel+).
+    #
+    # @param new_x [Integer] left edge of the new dirty area
+    # @param new_y [Integer] top edge of the new dirty area
+    # @param new_w [Integer] width of the new dirty area
+    # @param new_h [Integer] height of the new dirty area
+    # @return [void]
+    # rubocop:disable Style/MinMaxComparison -- ternaries avoid Array allocs on hot path
+    def expand_dirty(new_x, new_y, new_w, new_h)
+      if @dirty_x
+        right = new_x + new_w
+        bottom = new_y + new_h
+        old_right = @dirty_x + @dirty_w
+        old_bottom = @dirty_y + @dirty_h
+        @dirty_x = new_x < @dirty_x ? new_x : @dirty_x
+        @dirty_y = new_y < @dirty_y ? new_y : @dirty_y
+        @dirty_w = (right > old_right ? right : old_right) - @dirty_x
+        @dirty_h = (bottom > old_bottom ? bottom : old_bottom) - @dirty_y
+      else
+        @dirty_x = new_x
+        @dirty_y = new_y
+        @dirty_w = new_w
+        @dirty_h = new_h
+      end
+    end
+    # rubocop:enable Style/MinMaxComparison
+  end
+end

--- a/lib/chroma_wave/dirty_tracking.rb
+++ b/lib/chroma_wave/dirty_tracking.rb
@@ -14,20 +14,34 @@ module ChromaWave
   #     # ...
   #   end
   module DirtyTracking
+    # @!attribute [r] dirty_x
+    #   Left edge of the dirty bounding box, or +nil+ if clean.
+    #   @return [Integer, nil]
+    # @!attribute [r] dirty_y
+    #   Top edge of the dirty bounding box, or +nil+ if clean.
+    #   @return [Integer, nil]
+    # @!attribute [r] dirty_w
+    #   Width of the dirty bounding box, or +nil+ if clean.
+    #   @return [Integer, nil]
+    # @!attribute [r] dirty_h
+    #   Height of the dirty bounding box, or +nil+ if clean.
+    #   @return [Integer, nil]
+    attr_reader :dirty_x, :dirty_y, :dirty_w, :dirty_h
+
     # Returns true if any region has been marked dirty since the last {#clean!}.
     #
     # @return [Boolean]
     def dirty?
-      !@dirty_x.nil?
+      !dirty_x.nil?
     end
 
     # Returns the bounding box of all modifications since the last {#clean!}.
     #
     # @return [Rect, nil] the dirty bounding box or nil if clean
     def dirty_region
-      return nil unless @dirty_x
+      return nil unless dirty_x
 
-      Rect.new(x: @dirty_x, y: @dirty_y, width: @dirty_w, height: @dirty_h)
+      Rect.new(x: dirty_x, y: dirty_y, width: dirty_w, height: dirty_h)
     end
 
     # Resets dirty tracking, marking the surface as clean.
@@ -63,19 +77,19 @@ module ChromaWave
 
     private
 
-    # Copies dirty tracking ivars from +source+ into this instance.
+    # Copies dirty tracking state from +source+ into this instance.
     #
-    # Reads instance variables directly to avoid allocating an intermediate
-    # Rect. Intended for use in +initialize_copy+ to deep-copy dirty
-    # tracking state when duplicating or cloning the includer.
+    # Reads public accessors to avoid allocating an intermediate Rect.
+    # Intended for use in +initialize_copy+ to deep-copy dirty tracking
+    # state when duplicating or cloning the includer.
     #
     # @param source [DirtyTracking] the source to copy dirty state from
     # @return [void]
     def copy_dirty_state(source)
-      @dirty_x = source.instance_variable_get(:@dirty_x)
-      @dirty_y = source.instance_variable_get(:@dirty_y)
-      @dirty_w = source.instance_variable_get(:@dirty_w)
-      @dirty_h = source.instance_variable_get(:@dirty_h)
+      @dirty_x = source.dirty_x
+      @dirty_y = source.dirty_y
+      @dirty_w = source.dirty_w
+      @dirty_h = source.dirty_h
     end
 
     # Clips a rectangle to surface bounds and marks it dirty.
@@ -108,15 +122,15 @@ module ChromaWave
     # @return [void]
     # rubocop:disable Style/MinMaxComparison -- ternaries avoid Array allocs on hot path
     def expand_dirty(new_x, new_y, new_w, new_h)
-      if @dirty_x
+      if dirty_x
         right = new_x + new_w
         bottom = new_y + new_h
-        old_right = @dirty_x + @dirty_w
-        old_bottom = @dirty_y + @dirty_h
-        @dirty_x = new_x < @dirty_x ? new_x : @dirty_x
-        @dirty_y = new_y < @dirty_y ? new_y : @dirty_y
-        @dirty_w = (right > old_right ? right : old_right) - @dirty_x
-        @dirty_h = (bottom > old_bottom ? bottom : old_bottom) - @dirty_y
+        old_right = dirty_x + dirty_w
+        old_bottom = dirty_y + dirty_h
+        @dirty_x = new_x < dirty_x ? new_x : dirty_x
+        @dirty_y = new_y < dirty_y ? new_y : dirty_y
+        @dirty_w = (right > old_right ? right : old_right) - dirty_x
+        @dirty_h = (bottom > old_bottom ? bottom : old_bottom) - dirty_y
       else
         @dirty_x = new_x
         @dirty_y = new_y

--- a/lib/chroma_wave/dirty_tracking.rb
+++ b/lib/chroma_wave/dirty_tracking.rb
@@ -52,7 +52,7 @@ module ChromaWave
       if rect
         mark_clipped_dirty(rect.x, rect.y, rect.width, rect.height)
       else
-        unless x && y && width && height
+        if [x, y, width, height].any?(&:nil?)
           raise ArgumentError, 'mark_dirty requires a Rect or x:, y:, width:, height: keywords'
         end
 
@@ -63,23 +63,19 @@ module ChromaWave
 
     private
 
-    # Copies dirty state from +source+ into this instance.
+    # Copies dirty tracking ivars from +source+ into this instance.
     #
-    # Intended for use in +initialize_copy+ to deep-copy dirty tracking
-    # state when duplicating or cloning the includer.
+    # Reads instance variables directly to avoid allocating an intermediate
+    # Rect. Intended for use in +initialize_copy+ to deep-copy dirty
+    # tracking state when duplicating or cloning the includer.
     #
     # @param source [DirtyTracking] the source to copy dirty state from
     # @return [void]
     def copy_dirty_state(source)
-      region = source.dirty_region
-      if region
-        @dirty_x = region.x
-        @dirty_y = region.y
-        @dirty_w = region.width
-        @dirty_h = region.height
-      else
-        @dirty_x = @dirty_y = @dirty_w = @dirty_h = nil
-      end
+      @dirty_x = source.instance_variable_get(:@dirty_x)
+      @dirty_y = source.instance_variable_get(:@dirty_y)
+      @dirty_w = source.instance_variable_get(:@dirty_w)
+      @dirty_h = source.instance_variable_get(:@dirty_h)
     end
 
     # Clips a rectangle to surface bounds and marks it dirty.

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -326,18 +326,19 @@ module ChromaWave
 
     # Displays the dirty region using regional refresh.
     #
-    # @param framebuffer [Framebuffer] full-screen rendered framebuffer
-    # @param region [Hash] dirty region +{x:, y:, width:, height:}+
+    # @param framebuffer [Framebuffer] full-screen rendered framebuffer (logical space)
+    # @param region [Rect] dirty region bounding box
     # @param mode [Symbol, nil] display mode
     # @return [void]
     # @raise [ArgumentError] if mode is unrecognized or display lacks capability
     def display_dirty_regional(framebuffer, region, mode)
+      region_hash = region.to_h
       case mode
       when nil
-        display_region(framebuffer, **region)
+        display_region(framebuffer, **region_hash)
       when :partial
         raise_unless_capable!(:partial, Capabilities::PartialRefresh)
-        display_region(framebuffer, **region)
+        display_region(framebuffer, **region_hash)
       else
         raise ArgumentError, "unknown mode: #{mode.inspect}"
       end

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -111,14 +111,17 @@ module ChromaWave
     # +self+ immediately (no-op). Otherwise renders the full canvas (for dither
     # correctness) and pushes the dirty sub-region to hardware.
     #
-    # On {Capabilities::RegionalRefresh}-capable displays, uses +display_region+
-    # to update only the changed rectangle. On other displays, falls back to a
-    # full screen refresh.
+    # On {Capabilities::RegionalRefresh}-capable displays, always uses
+    # +display_region+ to update only the changed rectangle — +mode+ is
+    # ignored. On non-regional displays, falls back to a full-screen refresh
+    # by default, or to {Capabilities::PartialRefresh#display_partial} when
+    # +mode: :partial+ is specified.
     #
     # Always calls +canvas.clean!+ after a successful display operation.
     #
     # @param canvas [Canvas] the canvas to display
-    # @param mode [Symbol, nil] display mode (+nil+ for default, +:partial+ for partial refresh)
+    # @param mode [Symbol, nil] display mode (+nil+ for default, +:partial+
+    #   for partial refresh). Only affects the non-regional fallback path.
     # @return [self]
     # @raise [TypeError] if +canvas+ is not a Canvas
     # @raise [ArgumentError] if +mode+ is not recognized or display lacks the requested capability
@@ -332,13 +335,18 @@ module ChromaWave
 
     # Validates the display mode, raising for unknown or unsupported modes.
     #
+    # +:partial+ is accepted with {Capabilities::PartialRefresh} or
+    # {Capabilities::RegionalRefresh} (where +mode+ is ignored).
+    #
     # @param mode [Symbol, nil] the requested mode
     # @raise [ArgumentError] if mode is unrecognized or display lacks the capability
     def validate_display_mode!(mode)
       case mode
       when nil then nil
       when :partial
-        raise ArgumentError, 'display does not support partial mode' unless is_a?(Capabilities::PartialRefresh)
+        return if is_a?(Capabilities::PartialRefresh) || is_a?(Capabilities::RegionalRefresh)
+
+        raise ArgumentError, 'display does not support partial mode'
       else
         raise ArgumentError, "unknown mode: #{mode.inspect}"
       end

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -120,14 +120,15 @@ module ChromaWave
     # @param canvas [Canvas] the canvas to display
     # @param mode [Symbol, nil] display mode (+nil+ for default, +:partial+ for partial refresh)
     # @return [self]
+    # @raise [TypeError] if +canvas+ is not a Canvas
     # @raise [ArgumentError] if +mode+ is not recognized or display lacks the requested capability
     def show_dirty(canvas, mode: nil)
+      raise TypeError, "expected Canvas, got #{canvas.class}" unless canvas.is_a?(Canvas)
       return self unless canvas.dirty?
 
       validate_display_mode!(mode)
       validate_canvas_dimensions!(canvas)
       region = canvas.dirty_region
-      ensure_initialized!
 
       fb = renderer.render(canvas)
 

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -125,6 +125,7 @@ module ChromaWave
       return self unless canvas.dirty?
 
       validate_display_mode!(mode)
+      validate_canvas_dimensions!(canvas)
       region = canvas.dirty_region
       ensure_initialized!
 
@@ -345,7 +346,6 @@ module ChromaWave
     #
     # @param framebuffer [Framebuffer] full-screen rendered framebuffer (logical space)
     # @param region [Rect] dirty region bounding box
-    # @param mode [Symbol, nil] display mode (already validated)
     # @return [void]
     def display_dirty_regional(framebuffer, region)
       display_region(framebuffer,
@@ -367,6 +367,18 @@ module ChromaWave
       else
         show(framebuffer)
       end
+    end
+
+    # Validates that a canvas matches this display's logical dimensions.
+    #
+    # @param canvas [Canvas] the canvas to validate
+    # @raise [ArgumentError] if dimensions do not match
+    def validate_canvas_dimensions!(canvas)
+      return if canvas.width == width && canvas.height == height
+
+      raise ArgumentError,
+            "canvas dimensions #{canvas.width}x#{canvas.height} " \
+            "do not match display size #{width}x#{height}"
     end
 
     # Validates that a framebuffer's pixel format and dimensions match this display.

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -124,9 +124,10 @@ module ChromaWave
     # @raise [ArgumentError] if +mode+ is not recognized or display lacks the requested capability
     def show_dirty(canvas, mode: nil)
       raise TypeError, "expected Canvas, got #{canvas.class}" unless canvas.is_a?(Canvas)
-      return self unless canvas.dirty?
 
       validate_display_mode!(mode)
+      return self unless canvas.dirty?
+
       validate_canvas_dimensions!(canvas)
       region = canvas.dirty_region
 

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -105,6 +105,41 @@ module ChromaWave
       self
     end
 
+    # Renders and displays only the dirty region of a canvas.
+    #
+    # When the canvas is clean (no modifications since last +clean!+), returns
+    # +self+ immediately (no-op). Otherwise renders the full canvas (for dither
+    # correctness) and pushes the dirty sub-region to hardware.
+    #
+    # On {Capabilities::RegionalRefresh}-capable displays, uses +display_region+
+    # to update only the changed rectangle. On other displays, falls back to a
+    # full screen refresh.
+    #
+    # Always calls +canvas.clean!+ after a successful display operation.
+    #
+    # @param canvas [Canvas] the canvas to display
+    # @param mode [Symbol, nil] display mode (+nil+ for default, +:partial+ for partial refresh)
+    # @return [self]
+    # @raise [ArgumentError] if +mode+ is not recognized or display lacks the requested capability
+    def show_dirty(canvas, mode: nil)
+      return self unless canvas.dirty?
+
+      region = canvas.dirty_region
+      ensure_initialized!
+
+      fb = renderer.render(canvas)
+      fb = fb.rotate(rotation) unless rotation.zero?
+
+      if is_a?(Capabilities::RegionalRefresh)
+        display_dirty_regional(fb, region, mode)
+      else
+        display_dirty_fallback(fb, mode)
+      end
+
+      canvas.clean!
+      self
+    end
+
     # Clears the display to a solid color.
     #
     # When +color+ is +:white+ (the default), delegates to the hardware's
@@ -287,6 +322,57 @@ module ChromaWave
       opts = options == true ? {} : options
       @refresh_scheduler = RefreshScheduler.new(**opts)
       extend Capabilities::ManagedRefresh
+    end
+
+    # Displays the dirty region using regional refresh.
+    #
+    # @param framebuffer [Framebuffer] full-screen rendered framebuffer
+    # @param region [Hash] dirty region +{x:, y:, width:, height:}+
+    # @param mode [Symbol, nil] display mode
+    # @return [void]
+    # @raise [ArgumentError] if mode is unrecognized or display lacks capability
+    def display_dirty_regional(framebuffer, region, mode)
+      case mode
+      when nil
+        display_region(framebuffer, **region)
+      when :partial
+        raise_unless_capable!(:partial, Capabilities::PartialRefresh)
+        display_region(framebuffer, **region)
+      else
+        raise ArgumentError, "unknown mode: #{mode.inspect}"
+      end
+    end
+
+    # Falls back to full-screen refresh when regional refresh is unavailable.
+    #
+    # Routes through {#show} so that {Capabilities::ManagedRefresh} tracking
+    # wraps the operation automatically (tracked as full refresh).
+    #
+    # @param framebuffer [Framebuffer] full-screen rendered framebuffer (native orientation)
+    # @param mode [Symbol, nil] display mode
+    # @return [void]
+    # @raise [ArgumentError] if mode is unrecognized or display lacks capability
+    def display_dirty_fallback(framebuffer, mode)
+      case mode
+      when nil
+        show(framebuffer)
+      when :partial
+        raise_unless_capable!(:partial, Capabilities::PartialRefresh)
+        display_partial(framebuffer)
+      else
+        raise ArgumentError, "unknown mode: #{mode.inspect}"
+      end
+    end
+
+    # Raises +ArgumentError+ unless this display has the given capability.
+    #
+    # @param name [Symbol] capability name for error message
+    # @param mod [Module] the capability module to check
+    # @raise [ArgumentError] if the display does not include the capability
+    def raise_unless_capable!(name, mod)
+      return if is_a?(mod)
+
+      raise ArgumentError, "display does not support #{name} mode"
     end
 
     # Validates that a framebuffer's pixel format and dimensions match this display.

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -367,6 +367,8 @@ module ChromaWave
       if mode == :partial
         display_partial(framebuffer)
       else
+        # Framebuffer is already rotated to native orientation;
+        # enters show's Framebuffer branch (validate + display).
         show(framebuffer)
       end
     end

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -124,6 +124,7 @@ module ChromaWave
     def show_dirty(canvas, mode: nil)
       return self unless canvas.dirty?
 
+      validate_display_mode!(mode)
       region = canvas.dirty_region
       ensure_initialized!
 
@@ -131,7 +132,7 @@ module ChromaWave
 
       if is_a?(Capabilities::RegionalRefresh)
         # display_region expects logical-space FB and handles rotation internally
-        display_dirty_regional(fb, region, mode)
+        display_dirty_regional(fb, region)
       else
         # Full-screen path needs native-orientation FB
         fb = fb.rotate(rotation) unless rotation.zero?
@@ -326,24 +327,30 @@ module ChromaWave
       extend Capabilities::ManagedRefresh
     end
 
+    # Validates the display mode, raising for unknown or unsupported modes.
+    #
+    # @param mode [Symbol, nil] the requested mode
+    # @raise [ArgumentError] if mode is unrecognized or display lacks the capability
+    def validate_display_mode!(mode)
+      case mode
+      when nil then nil
+      when :partial
+        raise ArgumentError, 'display does not support partial mode' unless is_a?(Capabilities::PartialRefresh)
+      else
+        raise ArgumentError, "unknown mode: #{mode.inspect}"
+      end
+    end
+
     # Displays the dirty region using regional refresh.
     #
     # @param framebuffer [Framebuffer] full-screen rendered framebuffer (logical space)
     # @param region [Rect] dirty region bounding box
-    # @param mode [Symbol, nil] display mode
+    # @param mode [Symbol, nil] display mode (already validated)
     # @return [void]
-    # @raise [ArgumentError] if mode is unrecognized or display lacks capability
-    def display_dirty_regional(framebuffer, region, mode)
-      region_hash = region.to_h
-      case mode
-      when nil
-        display_region(framebuffer, **region_hash)
-      when :partial
-        raise_unless_capable!(:partial, Capabilities::PartialRefresh)
-        display_region(framebuffer, **region_hash)
-      else
-        raise ArgumentError, "unknown mode: #{mode.inspect}"
-      end
+    def display_dirty_regional(framebuffer, region)
+      display_region(framebuffer,
+                     x: region.x, y: region.y,
+                     width: region.width, height: region.height)
     end
 
     # Falls back to full-screen refresh when regional refresh is unavailable.
@@ -352,30 +359,14 @@ module ChromaWave
     # wraps the operation automatically (tracked as full refresh).
     #
     # @param framebuffer [Framebuffer] full-screen rendered framebuffer (native orientation)
-    # @param mode [Symbol, nil] display mode
+    # @param mode [Symbol, nil] display mode (already validated)
     # @return [void]
-    # @raise [ArgumentError] if mode is unrecognized or display lacks capability
     def display_dirty_fallback(framebuffer, mode)
-      case mode
-      when nil
-        show(framebuffer)
-      when :partial
-        raise_unless_capable!(:partial, Capabilities::PartialRefresh)
+      if mode == :partial
         display_partial(framebuffer)
       else
-        raise ArgumentError, "unknown mode: #{mode.inspect}"
+        show(framebuffer)
       end
-    end
-
-    # Raises +ArgumentError+ unless this display has the given capability.
-    #
-    # @param name [Symbol] capability name for error message
-    # @param mod [Module] the capability module to check
-    # @raise [ArgumentError] if the display does not include the capability
-    def raise_unless_capable!(name, mod)
-      return if is_a?(mod)
-
-      raise ArgumentError, "display does not support #{name} mode"
     end
 
     # Validates that a framebuffer's pixel format and dimensions match this display.

--- a/lib/chroma_wave/display.rb
+++ b/lib/chroma_wave/display.rb
@@ -128,11 +128,13 @@ module ChromaWave
       ensure_initialized!
 
       fb = renderer.render(canvas)
-      fb = fb.rotate(rotation) unless rotation.zero?
 
       if is_a?(Capabilities::RegionalRefresh)
+        # display_region expects logical-space FB and handles rotation internally
         display_dirty_regional(fb, region, mode)
       else
+        # Full-screen path needs native-orientation FB
+        fb = fb.rotate(rotation) unless rotation.zero?
         display_dirty_fallback(fb, mode)
       end
 

--- a/lib/chroma_wave/rect.rb
+++ b/lib/chroma_wave/rect.rb
@@ -27,6 +27,10 @@ module ChromaWave
       if other_or_x.is_a?(Rect)
         other_x, other_y, other_w, other_h = other_or_x.deconstruct
       else
+        unless other_y && other_w && other_h
+          raise ArgumentError,
+                'union requires a Rect or four positional arguments (x, y, width, height)'
+        end
         other_x = other_or_x
       end
 
@@ -40,9 +44,5 @@ module ChromaWave
       )
     end
 
-    # Returns a Hash representation of this rect.
-    #
-    # @return [Hash{Symbol => Integer}]
-    def to_h = { x:, y:, width:, height: }
   end
 end

--- a/lib/chroma_wave/rect.rb
+++ b/lib/chroma_wave/rect.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module ChromaWave
+  # Immutable rectangle value type for region tracking.
+  #
+  # Built on +Data.define+ for automatic equality, freeze, and pattern matching.
+  # Primarily used by dirty region tracking to represent bounding boxes.
+  #
+  # @example
+  #   r1 = Rect.new(x: 0, y: 0, width: 10, height: 10)
+  #   r2 = Rect.new(x: 5, y: 5, width: 10, height: 10)
+  #   r1.union(r2) # => Rect(x: 0, y: 0, width: 15, height: 15)
+  Rect = Data.define(:x, :y, :width, :height) do
+    # Returns the smallest rectangle that encloses both this rect and +other+.
+    #
+    # Accepts either a {Rect} or four positional arguments (x, y, width, height).
+    #
+    # @overload union(rect)
+    #   @param rect [Rect] the other rectangle
+    # @overload union(other_x, other_y, other_width, other_height)
+    #   @param other_x [Integer] left edge
+    #   @param other_y [Integer] top edge
+    #   @param other_width [Integer] width
+    #   @param other_height [Integer] height
+    # @return [Rect] the bounding union
+    def union(other_or_x, other_y = nil, other_w = nil, other_h = nil)
+      if other_or_x.is_a?(Rect)
+        other_x, other_y, other_w, other_h = other_or_x.deconstruct
+      else
+        other_x = other_or_x
+      end
+
+      new_x = [x, other_x].min
+      new_y = [y, other_y].min
+      Rect.new(
+        x: new_x,
+        y: new_y,
+        width: [x + width, other_x + other_w].max - new_x,
+        height: [y + height, other_y + other_h].max - new_y
+      )
+    end
+
+    # Returns a Hash representation of this rect.
+    #
+    # @return [Hash{Symbol => Integer}]
+    def to_h = { x:, y:, width:, height: }
+  end
+end

--- a/lib/chroma_wave/rect.rb
+++ b/lib/chroma_wave/rect.rb
@@ -11,6 +11,16 @@ module ChromaWave
   #   r2 = Rect.new(x: 5, y: 5, width: 10, height: 10)
   #   r1.union(r2) # => Rect(x: 0, y: 0, width: 15, height: 15)
   Rect = Data.define(:x, :y, :width, :height) do
+    # Validates that width and height are non-negative after initialization.
+    #
+    # @raise [ArgumentError] if width or height is negative
+    def initialize(x:, y:, width:, height:)
+      raise ArgumentError, "width must be non-negative, got #{width}" if width.negative?
+      raise ArgumentError, "height must be non-negative, got #{height}" if height.negative?
+
+      super
+    end
+
     # Returns the smallest rectangle that encloses both this rect and +other+.
     #
     # Accepts either a {Rect} or four positional arguments (x, y, width, height).

--- a/lib/chroma_wave/rect.rb
+++ b/lib/chroma_wave/rect.rb
@@ -37,7 +37,7 @@ module ChromaWave
       if other_or_x.is_a?(Rect)
         other_x, other_y, other_w, other_h = other_or_x.deconstruct
       else
-        unless other_y && other_w && other_h
+        if [other_y, other_w, other_h].any?(&:nil?)
           raise ArgumentError,
                 'union requires a Rect or four positional arguments (x, y, width, height)'
         end

--- a/lib/chroma_wave/rect.rb
+++ b/lib/chroma_wave/rect.rb
@@ -23,34 +23,16 @@ module ChromaWave
 
     # Returns the smallest rectangle that encloses both this rect and +other+.
     #
-    # Accepts either a {Rect} or four positional arguments (x, y, width, height).
-    #
-    # @overload union(rect)
-    #   @param rect [Rect] the other rectangle
-    # @overload union(other_x, other_y, other_width, other_height)
-    #   @param other_x [Integer] left edge
-    #   @param other_y [Integer] top edge
-    #   @param other_width [Integer] width
-    #   @param other_height [Integer] height
+    # @param other [Rect] the other rectangle
     # @return [Rect] the bounding union
-    def union(other_or_x, other_y = nil, other_w = nil, other_h = nil)
-      if other_or_x.is_a?(Rect)
-        other_x, other_y, other_w, other_h = other_or_x.deconstruct
-      else
-        if [other_y, other_w, other_h].any?(&:nil?)
-          raise ArgumentError,
-                'union requires a Rect or four positional arguments (x, y, width, height)'
-        end
-        other_x = other_or_x
-      end
-
-      new_x = [x, other_x].min
-      new_y = [y, other_y].min
+    def union(other)
+      new_x = [x, other.x].min
+      new_y = [y, other.y].min
       Rect.new(
         x: new_x,
         y: new_y,
-        width: [x + width, other_x + other_w].max - new_x,
-        height: [y + height, other_y + other_h].max - new_y
+        width: [x + width, other.x + other.width].max - new_x,
+        height: [y + height, other.y + other.height].max - new_y
       )
     end
   end

--- a/lib/chroma_wave/rect.rb
+++ b/lib/chroma_wave/rect.rb
@@ -43,6 +43,5 @@ module ChromaWave
         height: [y + height, other_y + other_h].max - new_y
       )
     end
-
   end
 end

--- a/lib/chroma_wave/renderer.rb
+++ b/lib/chroma_wave/renderer.rb
@@ -43,26 +43,6 @@ module ChromaWave
       framebuffer
     end
 
-    # Renders a Canvas into a Framebuffer, accepting a dirty region hint.
-    #
-    # Performs a full render (not region-constrained) because Floyd-Steinberg
-    # error diffusion propagates across pixel boundaries — constraining to a
-    # sub-region would produce visible seam artifacts.
-    #
-    # The +region+ parameter is accepted for API symmetry with {Display#show_dirty}
-    # but does not affect rendering. The performance win from dirty tracking is
-    # in the display refresh (hardware), not in Ruby rendering.
-    #
-    # @param canvas [Canvas] source RGBA canvas
-    # @param region [Hash] dirty region hint (unused — full render always)
-    # @param into [Framebuffer, nil] optional pre-allocated framebuffer to reuse
-    # @return [Framebuffer] the rendered framebuffer
-    # @raise [TypeError] if canvas is not a Canvas
-    # @raise [ArgumentError] if +into+ dimensions do not match the canvas
-    def render_region(canvas, region, into: nil) # rubocop:disable Lint/UnusedMethodArgument
-      render(canvas, into: into)
-    end
-
     # Renders a Canvas into two MONO Framebuffers for dual-buffer COLOR4 displays.
     #
     # Tri-color E-Paper displays use separate black and red planes.

--- a/lib/chroma_wave/renderer.rb
+++ b/lib/chroma_wave/renderer.rb
@@ -43,6 +43,26 @@ module ChromaWave
       framebuffer
     end
 
+    # Renders a Canvas into a Framebuffer, accepting a dirty region hint.
+    #
+    # Performs a full render (not region-constrained) because Floyd-Steinberg
+    # error diffusion propagates across pixel boundaries — constraining to a
+    # sub-region would produce visible seam artifacts.
+    #
+    # The +region+ parameter is accepted for API symmetry with {Display#show_dirty}
+    # but does not affect rendering. The performance win from dirty tracking is
+    # in the display refresh (hardware), not in Ruby rendering.
+    #
+    # @param canvas [Canvas] source RGBA canvas
+    # @param region [Hash] dirty region hint (unused — full render always)
+    # @param into [Framebuffer, nil] optional pre-allocated framebuffer to reuse
+    # @return [Framebuffer] the rendered framebuffer
+    # @raise [TypeError] if canvas is not a Canvas
+    # @raise [ArgumentError] if +into+ dimensions do not match the canvas
+    def render_region(canvas, region, into: nil) # rubocop:disable Lint/UnusedMethodArgument
+      render(canvas, into: into)
+    end
+
     # Renders a Canvas into two MONO Framebuffers for dual-buffer COLOR4 displays.
     #
     # Tri-color E-Paper displays use separate black and red planes.

--- a/spec/chroma_wave/dirty_tracking_spec.rb
+++ b/spec/chroma_wave/dirty_tracking_spec.rb
@@ -414,6 +414,25 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
         end
       end
 
+      context 'with a RegionalRefresh-capable display' do
+        let(:display) { ChromaWave::MockDevice.new(model: regional_model) }
+
+        after { display.close }
+
+        it 'accepts mode: :partial without raising' do
+          canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+          canvas.set_pixel(10, 10, black)
+          expect { display.show_dirty(canvas, mode: :partial) }.not_to raise_error
+        end
+
+        it 'still uses display_region (mode is ignored on regional path)' do
+          canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+          canvas.set_pixel(10, 10, black)
+          display.show_dirty(canvas, mode: :partial)
+          expect(display.operations(:show_region)).not_to be_empty
+        end
+      end
+
       context 'with an unknown mode' do
         let(:display) { ChromaWave::MockDevice.new(model: non_regional_model) }
 

--- a/spec/chroma_wave/dirty_tracking_spec.rb
+++ b/spec/chroma_wave/dirty_tracking_spec.rb
@@ -96,6 +96,16 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
         canvas.blit_glyph(bitmap, x: 5, y: 5, width: 2, height: 2, color: black)
         expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 5, y: 5, width: 2, height: 2))
       end
+
+      it 'clips the dirty region when glyph extends beyond canvas bounds' do
+        bitmap = ("\xFF" * 400).b # 20x20 fully opaque
+        canvas.blit_glyph(bitmap, x: 90, y: 40, width: 20, height: 20, color: black)
+        region = canvas.dirty_region
+        expect(region.x).to eq(90)
+        expect(region.y).to eq(40)
+        expect(region.width).to eq(10)  # clipped to canvas width (100 - 90)
+        expect(region.height).to eq(10) # clipped to canvas height (50 - 40)
+      end
     end
 
     describe 'dirty region expansion' do
@@ -166,6 +176,39 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       it 'raises ArgumentError with no arguments' do
         expect { canvas.mark_dirty }
           .to raise_error(ArgumentError, /mark_dirty requires/)
+      end
+
+      it 'clips to surface bounds when region extends beyond canvas' do
+        canvas.mark_dirty(x: 90, y: 40, width: 20, height: 20)
+        region = canvas.dirty_region
+        expect(region.x).to eq(90)
+        expect(region.y).to eq(40)
+        expect(region.width).to eq(10)  # clipped to 100 - 90
+        expect(region.height).to eq(10) # clipped to 50 - 40
+      end
+
+      it 'clips negative coordinates to zero' do
+        canvas.mark_dirty(x: -5, y: -3, width: 20, height: 15)
+        region = canvas.dirty_region
+        expect(region.x).to eq(0)
+        expect(region.y).to eq(0)
+        expect(region.width).to eq(15)  # 20 - 5 clipped
+        expect(region.height).to eq(12) # 15 - 3 clipped
+      end
+
+      it 'is a no-op when region is entirely out of bounds' do
+        canvas.mark_dirty(x: 200, y: 200, width: 10, height: 10)
+        expect(canvas).not_to be_dirty
+      end
+
+      it 'is a no-op for zero-width rect' do
+        canvas.mark_dirty(x: 5, y: 5, width: 0, height: 10)
+        expect(canvas).not_to be_dirty
+      end
+
+      it 'is a no-op for zero-height rect' do
+        canvas.mark_dirty(x: 5, y: 5, width: 10, height: 0)
+        expect(canvas).not_to be_dirty
       end
     end
   end
@@ -371,12 +414,26 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
 
         after { display.close }
 
-        it 'raises ArgumentError' do
+        it 'raises ArgumentError for unknown mode even when canvas is clean' do
           canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
           canvas.set_pixel(10, 10, black)
           expect { display.show_dirty(canvas, mode: :bogus) }
             .to raise_error(ArgumentError, /unknown mode/)
         end
+      end
+    end
+
+    describe 'canvas dimension mismatch' do
+      let(:display) { ChromaWave::MockDevice.new(model: non_regional_model) }
+
+      after { display.close }
+
+      it 'raises when canvas dimensions do not match display' do
+        canvas = ChromaWave::Canvas.new(width: 10, height: 10)
+        canvas.set_pixel(1, 1, black)
+        # The renderer produces a framebuffer matching canvas dimensions,
+        # which won't match the display's native dimensions.
+        expect { display.show_dirty(canvas) }.to raise_error(ArgumentError, /dimensions/)
       end
     end
   end

--- a/spec/chroma_wave/dirty_tracking_spec.rb
+++ b/spec/chroma_wave/dirty_tracking_spec.rb
@@ -296,6 +296,21 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       end
     end
 
+    describe 'on a rotated RegionalRefresh-capable display' do
+      let(:display) { ChromaWave::MockDevice.new(model: regional_model, rotation: 90) }
+
+      after { display.close }
+
+      it 'passes logical-space framebuffer to display_region (no double rotation)' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        canvas.set_pixel(10, 10, black)
+        # If show_dirty double-rotates, display_region's validate_logical_framebuffer!
+        # would raise because the FB dimensions wouldn't match logical display size.
+        expect { display.show_dirty(canvas) }.not_to raise_error
+        expect(display.operations(:show_region)).not_to be_empty
+      end
+    end
+
     describe 'on a non-RegionalRefresh display' do
       let(:display) { ChromaWave::MockDevice.new(model: non_regional_model) }
 

--- a/spec/chroma_wave/dirty_tracking_spec.rb
+++ b/spec/chroma_wave/dirty_tracking_spec.rb
@@ -1,0 +1,428 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
+  let(:white) { ChromaWave::Color::WHITE }
+  let(:black) { ChromaWave::Color::BLACK }
+  let(:red)   { ChromaWave::Color::RED }
+
+  describe 'Canvas dirty state' do
+    subject(:canvas) { ChromaWave::Canvas.new(width: 100, height: 50) }
+
+    describe '#dirty? on a fresh canvas' do
+      it 'returns false' do
+        expect(canvas).not_to be_dirty
+      end
+    end
+
+    describe '#dirty_region on a fresh canvas' do
+      it 'returns nil' do
+        expect(canvas.dirty_region).to be_nil
+      end
+    end
+
+    describe '#set_pixel' do
+      it 'marks the canvas dirty' do
+        canvas.set_pixel(10, 20, black)
+        expect(canvas).to be_dirty
+      end
+
+      it 'tracks a single-pixel dirty region' do
+        canvas.set_pixel(10, 20, black)
+        expect(canvas.dirty_region).to eq({ x: 10, y: 20, width: 1, height: 1 })
+      end
+
+      it 'does not mark dirty for out-of-bounds pixels' do
+        canvas.set_pixel(-1, 0, black)
+        canvas.set_pixel(100, 0, black)
+        expect(canvas).not_to be_dirty
+      end
+    end
+
+    describe '#clear' do
+      it 'marks the entire canvas dirty' do
+        canvas.clear(black)
+        expect(canvas.dirty_region).to eq({ x: 0, y: 0, width: 100, height: 50 })
+      end
+    end
+
+    describe '#fill_rect' do
+      it 'marks the filled region dirty (clipped)' do
+        canvas.fill_rect(10, 20, 30, 15, black)
+        expect(canvas.dirty_region).to eq({ x: 10, y: 20, width: 30, height: 15 })
+      end
+
+      it 'clips the dirty region to canvas bounds' do
+        canvas.fill_rect(-5, -5, 20, 20, black)
+        expect(canvas.dirty_region).to eq({ x: 0, y: 0, width: 15, height: 15 })
+      end
+
+      it 'does not mark dirty when rect is fully out of bounds' do
+        canvas.fill_rect(200, 200, 10, 10, black)
+        expect(canvas).not_to be_dirty
+      end
+    end
+
+    describe '#blit' do
+      it 'marks the blit region dirty' do
+        src = ChromaWave::Canvas.new(width: 20, height: 10, background: red)
+        canvas.blit(src, x: 5, y: 5)
+        expect(canvas.dirty_region).to eq({ x: 5, y: 5, width: 20, height: 10 })
+      end
+
+      it 'clips the dirty region for negative offsets' do
+        src = ChromaWave::Canvas.new(width: 10, height: 10, background: red)
+        canvas.blit(src, x: -3, y: -3)
+        expect(canvas.dirty_region).to eq({ x: 0, y: 0, width: 7, height: 7 })
+      end
+
+      it 'clips the dirty region at canvas bounds' do
+        src = ChromaWave::Canvas.new(width: 20, height: 20, background: red)
+        canvas.blit(src, x: 90, y: 40)
+        expect(canvas.dirty_region).to eq({ x: 90, y: 40, width: 10, height: 10 })
+      end
+    end
+
+    describe '#load_rgba_bytes' do
+      it 'marks the loaded region dirty' do
+        bytes = (black.to_rgba_bytes * 12) # 4x3
+        canvas.load_rgba_bytes(bytes, width: 4, height: 3, x: 10, y: 20)
+        expect(canvas.dirty_region).to eq({ x: 10, y: 20, width: 4, height: 3 })
+      end
+    end
+
+    describe '#blit_glyph' do
+      it 'marks the glyph region dirty' do
+        bitmap = "\xFF\xFF\xFF\xFF".b # 2x2 fully opaque
+        canvas.blit_glyph(bitmap, x: 5, y: 5, width: 2, height: 2, color: black)
+        expect(canvas.dirty_region).to eq({ x: 5, y: 5, width: 2, height: 2 })
+      end
+    end
+
+    describe 'dirty region expansion' do
+      it 'expands to union of all mutations' do
+        canvas.set_pixel(10, 10, black)
+        canvas.set_pixel(50, 40, black)
+        region = canvas.dirty_region
+        expect(region[:x]).to eq(10)
+        expect(region[:y]).to eq(10)
+        expect(region[:width]).to eq(41)  # 50 - 10 + 1
+        expect(region[:height]).to eq(31) # 40 - 10 + 1
+      end
+
+      it 'expands for fill_rect after set_pixel' do
+        canvas.set_pixel(0, 0, black)
+        canvas.fill_rect(80, 30, 10, 10, red)
+        region = canvas.dirty_region
+        expect(region[:x]).to eq(0)
+        expect(region[:y]).to eq(0)
+        expect(region[:width]).to eq(90)  # 80 + 10
+        expect(region[:height]).to eq(40) # 30 + 10
+      end
+    end
+
+    describe '#clean!' do
+      it 'resets dirty state' do
+        canvas.set_pixel(10, 10, black)
+        expect(canvas).to be_dirty
+
+        canvas.clean!
+        expect(canvas).not_to be_dirty
+        expect(canvas.dirty_region).to be_nil
+      end
+
+      it 'returns self for chaining' do
+        expect(canvas.clean!).to equal(canvas)
+      end
+
+      it 'allows dirty tracking to restart after cleaning' do
+        canvas.set_pixel(10, 10, black)
+        canvas.clean!
+        canvas.set_pixel(50, 40, red)
+        expect(canvas.dirty_region).to eq({ x: 50, y: 40, width: 1, height: 1 })
+      end
+    end
+
+    describe '#mark_dirty' do
+      it 'marks an arbitrary rect dirty with keywords' do
+        canvas.mark_dirty(x: 5, y: 10, width: 20, height: 15)
+        expect(canvas.dirty_region).to eq({ x: 5, y: 10, width: 20, height: 15 })
+      end
+
+      it 'accepts a Rect object' do
+        rect = ChromaWave::Rect.new(x: 3, y: 7, width: 12, height: 8)
+        canvas.mark_dirty(rect)
+        expect(canvas.dirty_region).to eq({ x: 3, y: 7, width: 12, height: 8 })
+      end
+
+      it 'returns self for chaining' do
+        expect(canvas.mark_dirty(x: 0, y: 0, width: 1, height: 1)).to equal(canvas)
+      end
+    end
+  end
+
+  describe 'Canvas dup/clone preserves dirty state' do
+    it 'copies dirty state to the duplicate' do
+      canvas = ChromaWave::Canvas.new(width: 20, height: 20)
+      canvas.set_pixel(5, 5, black)
+      copy = canvas.dup
+      expect(copy).to be_dirty
+      expect(copy.dirty_region).to eq(canvas.dirty_region)
+    end
+
+    it 'produces independent dirty state' do
+      canvas = ChromaWave::Canvas.new(width: 20, height: 20)
+      canvas.set_pixel(5, 5, black)
+      copy = canvas.dup
+      copy.clean!
+      expect(canvas).to be_dirty
+      expect(copy).not_to be_dirty
+    end
+
+    it 'copies clean state correctly' do
+      canvas = ChromaWave::Canvas.new(width: 20, height: 20)
+      copy = canvas.dup
+      expect(copy).not_to be_dirty
+    end
+  end
+
+  describe 'Layer dirty propagation' do
+    it 'propagates set_pixel to parent canvas dirty region' do
+      canvas = ChromaWave::Canvas.new(width: 100, height: 100)
+      layer = canvas.layer(x: 10, y: 20, width: 50, height: 30)
+      layer.set_pixel(5, 5, black)
+      # Layer translates (5,5) to parent (15,25)
+      expect(canvas.dirty_region).to eq({ x: 15, y: 25, width: 1, height: 1 })
+    end
+
+    it 'propagates clear to parent canvas dirty region' do
+      canvas = ChromaWave::Canvas.new(width: 100, height: 100)
+      layer = canvas.layer(x: 10, y: 20, width: 50, height: 30)
+      layer.clear(black)
+      # Layer.clear calls parent.fill_rect with translated coords
+      expect(canvas.dirty_region).to eq({ x: 10, y: 20, width: 50, height: 30 })
+    end
+
+    it 'propagates load_rgba_bytes to parent canvas dirty region' do
+      canvas = ChromaWave::Canvas.new(width: 100, height: 100)
+      layer = canvas.layer(x: 10, y: 20, width: 50, height: 30)
+      bytes = (black.to_rgba_bytes * 4) # 2x2
+      layer.load_rgba_bytes(bytes, width: 2, height: 2, x: 0, y: 0)
+      expect(canvas.dirty_region).to eq({ x: 10, y: 20, width: 2, height: 2 })
+    end
+  end
+
+  describe 'Drawing primitives dirty propagation' do
+    subject(:canvas) { ChromaWave::Canvas.new(width: 100, height: 100) }
+
+    it 'tracks dirty from draw_line via set_pixel' do
+      pen = ChromaWave::Pen.new(stroke: black)
+      canvas.draw_line(10, 10, 50, 50, pen: pen)
+      expect(canvas).to be_dirty
+      region = canvas.dirty_region
+      expect(region[:x]).to be <= 10
+      expect(region[:y]).to be <= 10
+    end
+
+    it 'tracks dirty from draw_rect via set_pixel' do
+      pen = ChromaWave::Pen.new(stroke: black)
+      canvas.draw_rect(10, 10, 30, 20, pen: pen)
+      expect(canvas).to be_dirty
+    end
+
+    it 'tracks dirty from draw_circle via set_pixel' do
+      pen = ChromaWave::Pen.new(stroke: black)
+      canvas.draw_circle(50, 50, 10, pen: pen)
+      expect(canvas).to be_dirty
+    end
+
+    it 'tracks dirty from fill_rect via Canvas#fill_rect' do
+      pen = ChromaWave::Pen.new(fill: black)
+      canvas.draw_rect(10, 10, 30, 20, pen: pen)
+      expect(canvas).to be_dirty
+    end
+  end
+
+  describe 'Display#show_dirty' do
+    # epd_2in7_v2 has RegionalRefresh capability
+    let(:regional_model) { :epd_2in7_v2 }
+    # epd_2in13_v4 does NOT have RegionalRefresh
+    let(:non_regional_model) { :epd_2in13_v4 }
+
+    describe 'on a RegionalRefresh-capable display' do
+      let(:display) { ChromaWave::MockDevice.new(model: regional_model) }
+
+      after { display.close }
+
+      it 'is a no-op when canvas is clean' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        result = display.show_dirty(canvas)
+        expect(result).to equal(display)
+        expect(display.operation_count).to eq(0)
+      end
+
+      it 'uses display_region for dirty canvas' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        display.show(canvas) # initial full show
+        display.clear_operations!
+
+        canvas.set_pixel(10, 10, black)
+        display.show_dirty(canvas)
+
+        # Should have used regional refresh (show_region op)
+        expect(display.operations(:show_region)).not_to be_empty
+      end
+
+      it 'cleans the canvas after successful display' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        canvas.set_pixel(10, 10, black)
+        display.show_dirty(canvas)
+        expect(canvas).not_to be_dirty
+      end
+
+      it 'returns self' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        canvas.set_pixel(10, 10, black)
+        expect(display.show_dirty(canvas)).to equal(display)
+      end
+    end
+
+    describe 'on a non-RegionalRefresh display' do
+      let(:display) { ChromaWave::MockDevice.new(model: non_regional_model) }
+
+      after { display.close }
+
+      it 'is a no-op when canvas is clean' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        display.show_dirty(canvas)
+        expect(display.operation_count).to eq(0)
+      end
+
+      it 'falls back to full refresh for dirty canvas' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        canvas.set_pixel(10, 10, black)
+        display.show_dirty(canvas)
+        # Should have used full show (not show_region)
+        expect(display.operations(:show_region)).to be_empty
+        expect(display.operations(:show)).not_to be_empty
+      end
+
+      it 'cleans the canvas after successful display' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        canvas.set_pixel(10, 10, black)
+        display.show_dirty(canvas)
+        expect(canvas).not_to be_dirty
+      end
+    end
+
+    describe 'show does NOT clean the canvas' do
+      let(:display) { ChromaWave::MockDevice.new(model: non_regional_model) }
+
+      after { display.close }
+
+      it 'preserves dirty state after show' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        canvas.set_pixel(10, 10, black)
+        display.show(canvas)
+        expect(canvas).to be_dirty
+      end
+    end
+
+    describe 'mode: :partial' do
+      context 'with a PartialRefresh-capable display' do
+        let(:display) { ChromaWave::MockDevice.new(model: non_regional_model) }
+
+        after { display.close }
+
+        it 'uses partial refresh when requested' do
+          canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+          canvas.set_pixel(10, 10, black)
+          display.show_dirty(canvas, mode: :partial)
+          expect(canvas).not_to be_dirty
+        end
+      end
+
+      context 'with an unknown mode' do
+        let(:display) { ChromaWave::MockDevice.new(model: non_regional_model) }
+
+        after { display.close }
+
+        it 'raises ArgumentError' do
+          canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+          canvas.set_pixel(10, 10, black)
+          expect { display.show_dirty(canvas, mode: :bogus) }
+            .to raise_error(ArgumentError, /unknown mode/)
+        end
+      end
+    end
+  end
+
+  describe 'ManagedRefresh#show_dirty' do
+    let(:regional_model) { :epd_2in7_v2 }
+    let(:non_regional_model) { :epd_2in13_v4 }
+
+    context 'with a regional display and managed refresh' do
+      let(:display) do
+        ChromaWave::MockDevice.new(model: regional_model, managed_refresh: true)
+      end
+
+      after { display.close }
+
+      it 'tracks as partial refresh' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        canvas.set_pixel(10, 10, black)
+        display.show_dirty(canvas)
+        expect(display.refresh_scheduler.partial_count).to eq(1)
+      end
+    end
+
+    context 'with a non-regional display and managed refresh' do
+      let(:display) do
+        ChromaWave::MockDevice.new(model: non_regional_model, managed_refresh: true)
+      end
+
+      after { display.close }
+
+      it 'tracks as full refresh' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        canvas.set_pixel(10, 10, black)
+        display.show_dirty(canvas)
+        expect(display.refresh_scheduler.partial_count).to eq(0)
+      end
+    end
+
+    context 'when canvas is clean' do
+      let(:display) do
+        ChromaWave::MockDevice.new(model: regional_model, managed_refresh: true)
+      end
+
+      after { display.close }
+
+      it 'is a no-op (no tracking)' do
+        canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
+        display.show_dirty(canvas)
+        expect(display.refresh_scheduler.partial_count).to eq(0)
+      end
+    end
+  end
+
+  describe 'Renderer#render_region' do
+    let(:renderer) { ChromaWave::Renderer.new(pixel_format: :mono, dither: :threshold) }
+
+    it 'returns a Framebuffer' do
+      canvas = ChromaWave::Canvas.new(width: 20, height: 20, background: black)
+      region = { x: 0, y: 0, width: 10, height: 10 }
+      fb = renderer.render_region(canvas, region)
+      expect(fb).to be_a(ChromaWave::Framebuffer)
+      expect(fb.width).to eq(20)
+      expect(fb.height).to eq(20)
+    end
+
+    it 'accepts an into: parameter' do
+      canvas = ChromaWave::Canvas.new(width: 20, height: 20, background: black)
+      existing = ChromaWave::Framebuffer.new(20, 20, ChromaWave::PixelFormat::MONO)
+      region = { x: 0, y: 0, width: 10, height: 10 }
+      result = renderer.render_region(canvas, region, into: existing)
+      expect(result).to equal(existing)
+    end
+  end
+end

--- a/spec/chroma_wave/dirty_tracking_spec.rb
+++ b/spec/chroma_wave/dirty_tracking_spec.rb
@@ -178,6 +178,11 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
           .to raise_error(ArgumentError, /mark_dirty requires/)
       end
 
+      it 'accepts zero-valued x and y without raising' do
+        canvas.mark_dirty(x: 0, y: 0, width: 10, height: 10)
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 0, y: 0, width: 10, height: 10))
+      end
+
       it 'clips to surface bounds when region extends beyond canvas' do
         canvas.mark_dirty(x: 90, y: 40, width: 20, height: 20)
         region = canvas.dirty_region
@@ -432,6 +437,16 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
         canvas = ChromaWave::Canvas.new(width: 10, height: 10)
         canvas.set_pixel(1, 1, black)
         expect { display.show_dirty(canvas) }.to raise_error(ArgumentError, /canvas dimensions.*do not match/)
+      end
+    end
+
+    describe 'type checking' do
+      let(:display) { ChromaWave::MockDevice.new(model: non_regional_model) }
+
+      after { display.close }
+
+      it 'raises TypeError for non-Canvas input' do
+        expect { display.show_dirty('not a canvas') }.to raise_error(TypeError, /expected Canvas/)
       end
     end
   end

--- a/spec/chroma_wave/dirty_tracking_spec.rb
+++ b/spec/chroma_wave/dirty_tracking_spec.rb
@@ -419,9 +419,15 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
 
         after { display.close }
 
-        it 'raises ArgumentError for unknown mode even when canvas is clean' do
+        it 'raises ArgumentError for unknown mode' do
           canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
           canvas.set_pixel(10, 10, black)
+          expect { display.show_dirty(canvas, mode: :bogus) }
+            .to raise_error(ArgumentError, /unknown mode/)
+        end
+
+        it 'raises ArgumentError for unknown mode even when canvas is clean' do
+          canvas = ChromaWave::Canvas.new(width: display.width, height: display.height)
           expect { display.show_dirty(canvas, mode: :bogus) }
             .to raise_error(ArgumentError, /unknown mode/)
         end

--- a/spec/chroma_wave/dirty_tracking_spec.rb
+++ b/spec/chroma_wave/dirty_tracking_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
 
       it 'tracks a single-pixel dirty region' do
         canvas.set_pixel(10, 20, black)
-        expect(canvas.dirty_region).to eq({ x: 10, y: 20, width: 1, height: 1 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 10, y: 20, width: 1, height: 1))
       end
 
       it 'does not mark dirty for out-of-bounds pixels' do
@@ -41,19 +41,19 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
     describe '#clear' do
       it 'marks the entire canvas dirty' do
         canvas.clear(black)
-        expect(canvas.dirty_region).to eq({ x: 0, y: 0, width: 100, height: 50 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 0, y: 0, width: 100, height: 50))
       end
     end
 
     describe '#fill_rect' do
       it 'marks the filled region dirty (clipped)' do
         canvas.fill_rect(10, 20, 30, 15, black)
-        expect(canvas.dirty_region).to eq({ x: 10, y: 20, width: 30, height: 15 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 10, y: 20, width: 30, height: 15))
       end
 
       it 'clips the dirty region to canvas bounds' do
         canvas.fill_rect(-5, -5, 20, 20, black)
-        expect(canvas.dirty_region).to eq({ x: 0, y: 0, width: 15, height: 15 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 0, y: 0, width: 15, height: 15))
       end
 
       it 'does not mark dirty when rect is fully out of bounds' do
@@ -66,19 +66,19 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       it 'marks the blit region dirty' do
         src = ChromaWave::Canvas.new(width: 20, height: 10, background: red)
         canvas.blit(src, x: 5, y: 5)
-        expect(canvas.dirty_region).to eq({ x: 5, y: 5, width: 20, height: 10 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 5, y: 5, width: 20, height: 10))
       end
 
       it 'clips the dirty region for negative offsets' do
         src = ChromaWave::Canvas.new(width: 10, height: 10, background: red)
         canvas.blit(src, x: -3, y: -3)
-        expect(canvas.dirty_region).to eq({ x: 0, y: 0, width: 7, height: 7 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 0, y: 0, width: 7, height: 7))
       end
 
       it 'clips the dirty region at canvas bounds' do
         src = ChromaWave::Canvas.new(width: 20, height: 20, background: red)
         canvas.blit(src, x: 90, y: 40)
-        expect(canvas.dirty_region).to eq({ x: 90, y: 40, width: 10, height: 10 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 90, y: 40, width: 10, height: 10))
       end
     end
 
@@ -86,7 +86,7 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       it 'marks the loaded region dirty' do
         bytes = (black.to_rgba_bytes * 12) # 4x3
         canvas.load_rgba_bytes(bytes, width: 4, height: 3, x: 10, y: 20)
-        expect(canvas.dirty_region).to eq({ x: 10, y: 20, width: 4, height: 3 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 10, y: 20, width: 4, height: 3))
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       it 'marks the glyph region dirty' do
         bitmap = "\xFF\xFF\xFF\xFF".b # 2x2 fully opaque
         canvas.blit_glyph(bitmap, x: 5, y: 5, width: 2, height: 2, color: black)
-        expect(canvas.dirty_region).to eq({ x: 5, y: 5, width: 2, height: 2 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 5, y: 5, width: 2, height: 2))
       end
     end
 
@@ -103,20 +103,20 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
         canvas.set_pixel(10, 10, black)
         canvas.set_pixel(50, 40, black)
         region = canvas.dirty_region
-        expect(region[:x]).to eq(10)
-        expect(region[:y]).to eq(10)
-        expect(region[:width]).to eq(41)  # 50 - 10 + 1
-        expect(region[:height]).to eq(31) # 40 - 10 + 1
+        expect(region.x).to eq(10)
+        expect(region.y).to eq(10)
+        expect(region.width).to eq(41)  # 50 - 10 + 1
+        expect(region.height).to eq(31) # 40 - 10 + 1
       end
 
       it 'expands for fill_rect after set_pixel' do
         canvas.set_pixel(0, 0, black)
         canvas.fill_rect(80, 30, 10, 10, red)
         region = canvas.dirty_region
-        expect(region[:x]).to eq(0)
-        expect(region[:y]).to eq(0)
-        expect(region[:width]).to eq(90)  # 80 + 10
-        expect(region[:height]).to eq(40) # 30 + 10
+        expect(region.x).to eq(0)
+        expect(region.y).to eq(0)
+        expect(region.width).to eq(90)  # 80 + 10
+        expect(region.height).to eq(40) # 30 + 10
       end
     end
 
@@ -138,24 +138,34 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
         canvas.set_pixel(10, 10, black)
         canvas.clean!
         canvas.set_pixel(50, 40, red)
-        expect(canvas.dirty_region).to eq({ x: 50, y: 40, width: 1, height: 1 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 50, y: 40, width: 1, height: 1))
       end
     end
 
     describe '#mark_dirty' do
       it 'marks an arbitrary rect dirty with keywords' do
         canvas.mark_dirty(x: 5, y: 10, width: 20, height: 15)
-        expect(canvas.dirty_region).to eq({ x: 5, y: 10, width: 20, height: 15 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 5, y: 10, width: 20, height: 15))
       end
 
       it 'accepts a Rect object' do
         rect = ChromaWave::Rect.new(x: 3, y: 7, width: 12, height: 8)
         canvas.mark_dirty(rect)
-        expect(canvas.dirty_region).to eq({ x: 3, y: 7, width: 12, height: 8 })
+        expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 3, y: 7, width: 12, height: 8))
       end
 
       it 'returns self for chaining' do
         expect(canvas.mark_dirty(x: 0, y: 0, width: 1, height: 1)).to equal(canvas)
+      end
+
+      it 'raises ArgumentError when keyword args are missing' do
+        expect { canvas.mark_dirty(x: 5, y: 10) }
+          .to raise_error(ArgumentError, /mark_dirty requires/)
+      end
+
+      it 'raises ArgumentError with no arguments' do
+        expect { canvas.mark_dirty }
+          .to raise_error(ArgumentError, /mark_dirty requires/)
       end
     end
   end
@@ -191,7 +201,7 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       layer = canvas.layer(x: 10, y: 20, width: 50, height: 30)
       layer.set_pixel(5, 5, black)
       # Layer translates (5,5) to parent (15,25)
-      expect(canvas.dirty_region).to eq({ x: 15, y: 25, width: 1, height: 1 })
+      expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 15, y: 25, width: 1, height: 1))
     end
 
     it 'propagates clear to parent canvas dirty region' do
@@ -199,7 +209,7 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       layer = canvas.layer(x: 10, y: 20, width: 50, height: 30)
       layer.clear(black)
       # Layer.clear calls parent.fill_rect with translated coords
-      expect(canvas.dirty_region).to eq({ x: 10, y: 20, width: 50, height: 30 })
+      expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 10, y: 20, width: 50, height: 30))
     end
 
     it 'propagates load_rgba_bytes to parent canvas dirty region' do
@@ -207,7 +217,7 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       layer = canvas.layer(x: 10, y: 20, width: 50, height: 30)
       bytes = (black.to_rgba_bytes * 4) # 2x2
       layer.load_rgba_bytes(bytes, width: 2, height: 2, x: 0, y: 0)
-      expect(canvas.dirty_region).to eq({ x: 10, y: 20, width: 2, height: 2 })
+      expect(canvas.dirty_region).to eq(ChromaWave::Rect.new(x: 10, y: 20, width: 2, height: 2))
     end
   end
 
@@ -219,8 +229,8 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       canvas.draw_line(10, 10, 50, 50, pen: pen)
       expect(canvas).to be_dirty
       region = canvas.dirty_region
-      expect(region[:x]).to be <= 10
-      expect(region[:y]).to be <= 10
+      expect(region.x).to be <= 10
+      expect(region.y).to be <= 10
     end
 
     it 'tracks dirty from draw_rect via set_pixel' do

--- a/spec/chroma_wave/dirty_tracking_spec.rb
+++ b/spec/chroma_wave/dirty_tracking_spec.rb
@@ -431,9 +431,7 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       it 'raises when canvas dimensions do not match display' do
         canvas = ChromaWave::Canvas.new(width: 10, height: 10)
         canvas.set_pixel(1, 1, black)
-        # The renderer produces a framebuffer matching canvas dimensions,
-        # which won't match the display's native dimensions.
-        expect { display.show_dirty(canvas) }.to raise_error(ArgumentError, /dimensions/)
+        expect { display.show_dirty(canvas) }.to raise_error(ArgumentError, /canvas dimensions.*do not match/)
       end
     end
   end

--- a/spec/chroma_wave/dirty_tracking_spec.rb
+++ b/spec/chroma_wave/dirty_tracking_spec.rb
@@ -429,25 +429,4 @@ RSpec.describe 'Dirty region tracking' do # rubocop:disable RSpec/DescribeClass
       end
     end
   end
-
-  describe 'Renderer#render_region' do
-    let(:renderer) { ChromaWave::Renderer.new(pixel_format: :mono, dither: :threshold) }
-
-    it 'returns a Framebuffer' do
-      canvas = ChromaWave::Canvas.new(width: 20, height: 20, background: black)
-      region = { x: 0, y: 0, width: 10, height: 10 }
-      fb = renderer.render_region(canvas, region)
-      expect(fb).to be_a(ChromaWave::Framebuffer)
-      expect(fb.width).to eq(20)
-      expect(fb.height).to eq(20)
-    end
-
-    it 'accepts an into: parameter' do
-      canvas = ChromaWave::Canvas.new(width: 20, height: 20, background: black)
-      existing = ChromaWave::Framebuffer.new(20, 20, ChromaWave::PixelFormat::MONO)
-      region = { x: 0, y: 0, width: 10, height: 10 }
-      result = renderer.render_region(canvas, region, into: existing)
-      expect(result).to equal(existing)
-    end
-  end
 end

--- a/spec/chroma_wave/rect_spec.rb
+++ b/spec/chroma_wave/rect_spec.rb
@@ -64,12 +64,22 @@ RSpec.describe ChromaWave::Rect do
         expect(result).to eq(described_class.new(x: 0, y: 0, width: 15, height: 15))
       end
     end
-  end
 
-  describe '#to_h' do
-    it 'returns a hash with x, y, width, height keys' do
-      rect = described_class.new(x: 1, y: 2, width: 3, height: 4)
-      expect(rect.to_h).to eq({ x: 1, y: 2, width: 3, height: 4 })
+    context 'with missing positional arguments' do
+      it 'raises ArgumentError when y is missing' do
+        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
+        expect { a.union(5) }.to raise_error(ArgumentError, /four positional arguments/)
+      end
+
+      it 'raises ArgumentError when width and height are missing' do
+        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
+        expect { a.union(5, 5) }.to raise_error(ArgumentError, /four positional arguments/)
+      end
+
+      it 'raises ArgumentError when height is missing' do
+        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
+        expect { a.union(5, 5, 10) }.to raise_error(ArgumentError, /four positional arguments/)
+      end
     end
   end
 

--- a/spec/chroma_wave/rect_spec.rb
+++ b/spec/chroma_wave/rect_spec.rb
@@ -79,6 +79,12 @@ RSpec.describe ChromaWave::Rect do
         result = a.union(5, 5, 10, 10)
         expect(result).to eq(described_class.new(x: 0, y: 0, width: 15, height: 15))
       end
+
+      it 'accepts zero-valued y without raising' do
+        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
+        result = a.union(5, 0, 10, 10)
+        expect(result).to eq(described_class.new(x: 0, y: 0, width: 15, height: 10))
+      end
     end
 
     context 'with negative coordinates' do

--- a/spec/chroma_wave/rect_spec.rb
+++ b/spec/chroma_wave/rect_spec.rb
@@ -14,6 +14,22 @@ RSpec.describe ChromaWave::Rect do
       rect = described_class.new(x: 0, y: 0, width: 5, height: 5)
       expect(rect).to be_frozen
     end
+
+    it 'allows zero width and height' do
+      rect = described_class.new(x: 0, y: 0, width: 0, height: 0)
+      expect(rect.width).to eq(0)
+      expect(rect.height).to eq(0)
+    end
+
+    it 'raises ArgumentError for negative width' do
+      expect { described_class.new(x: 0, y: 0, width: -1, height: 5) }
+        .to raise_error(ArgumentError, /width must be non-negative/)
+    end
+
+    it 'raises ArgumentError for negative height' do
+      expect { described_class.new(x: 0, y: 0, width: 5, height: -1) }
+        .to raise_error(ArgumentError, /height must be non-negative/)
+    end
   end
 
   describe 'equality' do

--- a/spec/chroma_wave/rect_spec.rb
+++ b/spec/chroma_wave/rect_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe ChromaWave::Rect do
+  describe '.new' do
+    it 'creates a rect with the given attributes' do
+      rect = described_class.new(x: 1, y: 2, width: 10, height: 20)
+      expect(rect.x).to eq(1)
+      expect(rect.y).to eq(2)
+      expect(rect.width).to eq(10)
+      expect(rect.height).to eq(20)
+    end
+
+    it 'is frozen' do
+      rect = described_class.new(x: 0, y: 0, width: 5, height: 5)
+      expect(rect).to be_frozen
+    end
+  end
+
+  describe 'equality' do
+    it 'considers rects with the same attributes equal' do
+      a = described_class.new(x: 1, y: 2, width: 3, height: 4)
+      b = described_class.new(x: 1, y: 2, width: 3, height: 4)
+      expect(a).to eq(b)
+    end
+
+    it 'considers rects with different attributes not equal' do
+      a = described_class.new(x: 1, y: 2, width: 3, height: 4)
+      b = described_class.new(x: 1, y: 2, width: 3, height: 5)
+      expect(a).not_to eq(b)
+    end
+  end
+
+  describe '#union' do
+    context 'with overlapping rects' do
+      it 'returns the bounding rect' do
+        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
+        b = described_class.new(x: 5, y: 5, width: 10, height: 10)
+        result = a.union(b)
+        expect(result).to eq(described_class.new(x: 0, y: 0, width: 15, height: 15))
+      end
+    end
+
+    context 'with non-overlapping rects' do
+      it 'returns the bounding rect spanning the gap' do
+        a = described_class.new(x: 0, y: 0, width: 5, height: 5)
+        b = described_class.new(x: 10, y: 10, width: 5, height: 5)
+        result = a.union(b)
+        expect(result).to eq(described_class.new(x: 0, y: 0, width: 15, height: 15))
+      end
+    end
+
+    context 'when one rect contains the other' do
+      it 'returns the larger rect' do
+        outer = described_class.new(x: 0, y: 0, width: 20, height: 20)
+        inner = described_class.new(x: 5, y: 5, width: 5, height: 5)
+        expect(outer.union(inner)).to eq(outer)
+      end
+    end
+
+    context 'with positional arguments' do
+      it 'accepts four positional args' do
+        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
+        result = a.union(5, 5, 10, 10)
+        expect(result).to eq(described_class.new(x: 0, y: 0, width: 15, height: 15))
+      end
+    end
+  end
+
+  describe '#to_h' do
+    it 'returns a hash with x, y, width, height keys' do
+      rect = described_class.new(x: 1, y: 2, width: 3, height: 4)
+      expect(rect.to_h).to eq({ x: 1, y: 2, width: 3, height: 4 })
+    end
+  end
+
+  describe '#deconstruct' do
+    it 'supports array destructuring' do
+      rect = described_class.new(x: 1, y: 2, width: 3, height: 4)
+      x, y, w, h = rect.deconstruct
+      expect([x, y, w, h]).to eq([1, 2, 3, 4])
+    end
+  end
+
+  describe '#deconstruct_keys' do
+    it 'supports pattern matching' do
+      rect = described_class.new(x: 1, y: 2, width: 3, height: 4)
+      case rect
+      in { x: Integer => x, width: Integer => w }
+        expect(x).to eq(1)
+        expect(w).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/chroma_wave/rect_spec.rb
+++ b/spec/chroma_wave/rect_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe ChromaWave::Rect do
       end
     end
 
+    context 'with negative coordinates' do
+      it 'handles negative x and y correctly' do
+        a = described_class.new(x: -5, y: -3, width: 10, height: 8)
+        b = described_class.new(x: 2, y: 1, width: 6, height: 4)
+        result = a.union(b)
+        expect(result).to eq(described_class.new(x: -5, y: -3, width: 13, height: 8))
+      end
+    end
+
     context 'with missing positional arguments' do
       it 'raises ArgumentError when y is missing' do
         a = described_class.new(x: 0, y: 0, width: 10, height: 10)

--- a/spec/chroma_wave/rect_spec.rb
+++ b/spec/chroma_wave/rect_spec.rb
@@ -73,43 +73,12 @@ RSpec.describe ChromaWave::Rect do
       end
     end
 
-    context 'with positional arguments' do
-      it 'accepts four positional args' do
-        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
-        result = a.union(5, 5, 10, 10)
-        expect(result).to eq(described_class.new(x: 0, y: 0, width: 15, height: 15))
-      end
-
-      it 'accepts zero-valued y without raising' do
-        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
-        result = a.union(5, 0, 10, 10)
-        expect(result).to eq(described_class.new(x: 0, y: 0, width: 15, height: 10))
-      end
-    end
-
     context 'with negative coordinates' do
       it 'handles negative x and y correctly' do
         a = described_class.new(x: -5, y: -3, width: 10, height: 8)
         b = described_class.new(x: 2, y: 1, width: 6, height: 4)
         result = a.union(b)
         expect(result).to eq(described_class.new(x: -5, y: -3, width: 13, height: 8))
-      end
-    end
-
-    context 'with missing positional arguments' do
-      it 'raises ArgumentError when y is missing' do
-        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
-        expect { a.union(5) }.to raise_error(ArgumentError, /four positional arguments/)
-      end
-
-      it 'raises ArgumentError when width and height are missing' do
-        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
-        expect { a.union(5, 5) }.to raise_error(ArgumentError, /four positional arguments/)
-      end
-
-      it 'raises ArgumentError when height is missing' do
-        a = described_class.new(x: 0, y: 0, width: 10, height: 10)
-        expect { a.union(5, 5, 10) }.to raise_error(ArgumentError, /four positional arguments/)
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds bounding-box dirty region tracking to Canvas and incremental refresh support to Display via `show_dirty`. When only a small part of the canvas changes, `show_dirty` pushes just the dirty sub-region to hardware on RegionalRefresh-capable displays, or falls back to a full refresh on others. This avoids unnecessary full-screen redraws for small UI updates.

## Changes

- **`lib/chroma_wave/rect.rb`** — New `Rect` immutable value type built on `Data.define`, with validation and `#union` for bounding box merging.
- **`lib/chroma_wave/dirty_tracking.rb`** — New `DirtyTracking` mixin providing `dirty?`, `dirty_region`, `clean!`, `mark_dirty`, and internal `expand_dirty`/`mark_clipped_dirty` helpers. Designed for any class implementing the Surface protocol (`width`/`height`).
- **`lib/chroma_wave/canvas.rb`** — Includes `DirtyTracking`. All mutation methods (`set_pixel`, `clear`, `fill_rect`, `blit`, `load_rgba_bytes`, `blit_glyph`, `render_glyph`) now expand the dirty bounding box. `initialize_copy` deep-copies dirty state.
- **`lib/chroma_wave/display.rb`** — New `Display#show_dirty` method dispatches to `display_region` (RegionalRefresh path) or full-screen fallback, with mode validation and canvas dimension checks. Always calls `canvas.clean!` after display.
- **`lib/chroma_wave.rb`** — Adds require entries for `rect` and `dirty_tracking`.
- **`.rubocop.yml`** — Bumps `Metrics/ClassLength` max from 150→190 to accommodate new Display methods.

## Type of Change

- [x] `feat:` New feature (dirty region tracking, `show_dirty`, `Rect`)
- [x] `test:` New test coverage (71 specs)
- [x] `refactor:` Extracted `DirtyTracking` as a composable mixin

## Testing

- **71 new specs** across `dirty_tracking_spec.rb` and `rect_spec.rb`
- **Full suite green**: 1480 examples, 0 failures, 6 pending (gray4 hardware)
- **Coverage**: 96.33% line / 88.51% branch (above thresholds)
- **Rubocop**: 0 offenses on all changed files
- Scenarios covered:
  - Per-operation dirty tracking (`set_pixel`, `clear`, `fill_rect`, `blit`, `load_rgba_bytes`, `blit_glyph`)
  - Dirty region expansion (union of multiple mutations)
  - Clipping to surface bounds (negative coords, overflows, fully OOB → no-op)
  - Zero-width/height rects → no-op
  - `clean!` reset and re-tracking cycle
  - `dup`/`clone` produce independent dirty state
  - Layer dirty propagation to parent canvas
  - Drawing primitives (`draw_line`, `draw_rect`, `draw_circle`) propagation via `set_pixel`
  - `Display#show_dirty` on RegionalRefresh displays (uses `display_region`)
  - `Display#show_dirty` on non-regional displays (falls back to full refresh)
  - Rotated display: no double rotation on regional path
  - `ManagedRefresh` integration (tracks partial vs full)
  - Mode validation (`:partial`, unknown modes, clean canvas)
  - Canvas dimension mismatch and type checking errors

## Notes for Reviewers

- `expand_dirty` uses ternaries over `[a,b].min/max` to avoid Array allocations on the `set_pixel` hot path (called per-pixel). Has a rubocop disable with justification.
- `show_dirty` doesn't call `ensure_initialized!` directly — all downstream paths (`display_region`, `display_partial`, `show`) handle it internally.
- Full canvas render is always performed even for small dirty regions, because dithering requires global pixel context for correctness. Only the *display push* is regionalized.
- `show` intentionally does NOT clean the canvas (tested) — only `show_dirty` manages the dirty lifecycle.

## How this Makes You Feel

🎯📐🧹⚡🔬