### PR TITLE
feat: Add Canvas#flip, #scale, #crop transforms

### DIFF
--- a/lib/chroma_wave/canvas.rb
+++ b/lib/chroma_wave/canvas.rb
@@ -348,3 +348,5 @@ module ChromaWave
     end
   end
 end
+
+require_relative 'canvas/transforms'

--- a/lib/chroma_wave/canvas/transforms.rb
+++ b/lib/chroma_wave/canvas/transforms.rb
@@ -63,6 +63,8 @@ module ChromaWave
       # @raise [ArgumentError] if +width+ or +height+ is not a positive Numeric,
       #   or if the clipped region is entirely outside the canvas
       def crop(x:, y:, width:, height:)
+        raise ArgumentError, 'crop x must be Numeric' unless x.is_a?(Numeric)
+        raise ArgumentError, 'crop y must be Numeric' unless y.is_a?(Numeric)
         raise ArgumentError, 'crop width must be a positive Numeric' unless width.is_a?(Numeric) && width.positive?
         raise ArgumentError, 'crop height must be a positive Numeric' unless height.is_a?(Numeric) && height.positive?
 
@@ -74,8 +76,10 @@ module ChromaWave
       # Builds a new Canvas directly from a pre-filled RGBA buffer.
       #
       # Bypasses +initialize+'s background-fill step so transforms can
-      # construct the output without writing pixels twice. The buffer is
-      # always duplicated to guarantee isolation from the caller.
+      # construct the output without writing pixels twice.
+      #
+      # *Ownership:* this method takes ownership of +buf+. The caller
+      # must not retain or mutate the string after passing it in.
       #
       # @param w   [Integer] canvas width
       # @param h   [Integer] canvas height
@@ -91,7 +95,7 @@ module ChromaWave
         self.class.allocate.tap do |canvas|
           canvas.instance_variable_set(:@width, w)
           canvas.instance_variable_set(:@height, h)
-          canvas.instance_variable_set(:@buffer, buf.dup.force_encoding(Encoding::BINARY))
+          canvas.instance_variable_set(:@buffer, buf.force_encoding(Encoding::BINARY))
         end
       end
 
@@ -105,6 +109,7 @@ module ChromaWave
 
         height.times do |row_y|
           row_start = row_y * row_bytes
+          # Each RGBA pixel is 4 bytes = one uint32 (V format)
           out << src.byteslice(row_start, row_bytes).unpack('V*').reverse.pack('V*')
         end
 

--- a/lib/chroma_wave/canvas/transforms.rb
+++ b/lib/chroma_wave/canvas/transforms.rb
@@ -167,10 +167,10 @@ module ChromaWave
       # @return [Array(Integer, Integer)]
       # @raise [ArgumentError] on invalid or conflicting arguments
       def resolve_scale_dimensions(factor, target_w, target_h)
-        new_w, new_h = if factor
-                         resolve_scale_factor(factor, target_w, target_h)
-                       else
+        new_w, new_h = if factor.nil?
                          resolve_scale_keywords(target_w, target_h)
+                       else
+                         resolve_scale_factor(factor, target_w, target_h)
                        end
 
         max = Surface::MAX_DIMENSION
@@ -196,28 +196,47 @@ module ChromaWave
 
       # Nearest-neighbor resampling into a +new_w+ x +new_h+ canvas.
       #
-      # Pre-computes the source-x lookup table to avoid per-pixel division,
-      # and builds each output row as a single string before appending.
+      # Pre-computes the source-x lookup table to avoid per-pixel division.
+      # Writes directly into a pre-allocated buffer via +setbyte+/+getbyte+
+      # to avoid per-pixel String allocations.
       #
       # @param new_w [Integer] output width
       # @param new_h [Integer] output height
       # @return [Canvas]
       def scale_nearest(new_w, new_h)
         src = raw_buffer
-        src_w = width
-        out = String.new(capacity: new_w * new_h * BYTES_PER_PIXEL, encoding: Encoding::BINARY)
+        out = ("\0" * (new_w * new_h * BYTES_PER_PIXEL)).b
+        x_map = Array.new(new_w) { |dx| (dx * width / new_w) * BYTES_PER_PIXEL }
 
-        # Pre-compute source x byte-offset for each destination column
-        x_map = Array.new(new_w) { |dx| (dx * src_w / new_w) * BYTES_PER_PIXEL }
+        copy_scaled_pixels(src, out, new_w, new_h, x_map)
+        build_canvas(new_w, new_h, out)
+      end
+
+      # Copies source pixels into +out+ using nearest-neighbor sampling.
+      #
+      # @param src   [String] source RGBA buffer
+      # @param out   [String] pre-allocated destination buffer (mutated in place)
+      # @param new_w [Integer] output width
+      # @param new_h [Integer] output height
+      # @param x_map [Array<Integer>] pre-computed source x byte-offsets
+      # @return [void]
+      def copy_scaled_pixels(src, out, new_w, new_h, x_map)
+        src_row_bytes = width * BYTES_PER_PIXEL
+        dest_row_bytes = new_w * BYTES_PER_PIXEL
 
         new_h.times do |dy|
-          src_row = (dy * height / new_h) * src_w * BYTES_PER_PIXEL
-          row = String.new(capacity: new_w * BYTES_PER_PIXEL, encoding: Encoding::BINARY)
-          x_map.each { |src_x| row << src.byteslice(src_row + src_x, BYTES_PER_PIXEL) }
-          out << row
-        end
+          src_row = (dy * height / new_h) * src_row_bytes
+          dest_row = dy * dest_row_bytes
 
-        build_canvas(new_w, new_h, out)
+          x_map.each_with_index do |src_x, dx|
+            src_pixel = src_row + src_x
+            dest_pixel = dest_row + (dx * BYTES_PER_PIXEL)
+
+            BYTES_PER_PIXEL.times do |b|
+              out.setbyte(dest_pixel + b, src.getbyte(src_pixel + b))
+            end
+          end
+        end
       end
 
       # Clips the crop rectangle to canvas bounds and copies rows.

--- a/lib/chroma_wave/canvas/transforms.rb
+++ b/lib/chroma_wave/canvas/transforms.rb
@@ -13,39 +13,6 @@ module ChromaWave
     #
     # Included into {Canvas} at the bottom of this file.
     module Transforms
-      # Hooks the +ClassMethods+ extension when included.
-      def self.included(base)
-        base.extend(ClassMethods)
-      end
-
-      # Class-level factory methods added to {Canvas}.
-      module ClassMethods
-        private
-
-        # Builds a Canvas directly from a pre-filled RGBA buffer.
-        #
-        # Bypasses +initialize+'s background-fill step so transforms can
-        # construct the output without writing pixels twice.
-        #
-        # @param width  [Integer] canvas width in pixels
-        # @param height [Integer] canvas height in pixels
-        # @param buf    [String]  raw RGBA bytes (+width * height * 4+ bytes)
-        # @return [Canvas]
-        # @raise [ArgumentError] if dimensions or buffer size are invalid
-        def from_buffer(width, height, buf)
-          Surface.validate_dimensions!(width, height)
-
-          expected = width * height * BYTES_PER_PIXEL
-          raise ArgumentError, "buffer size #{buf.bytesize} != #{expected}" unless buf.bytesize == expected
-
-          allocate.tap do |canvas|
-            canvas.instance_variable_set(:@width, width)
-            canvas.instance_variable_set(:@height, height)
-            canvas.instance_variable_set(:@buffer, buf.encoding == Encoding::BINARY ? buf : buf.b)
-          end
-        end
-      end
-
       # Mirrors the canvas horizontally or vertically.
       #
       # @param direction [:horizontal, :vertical] the flip axis
@@ -88,21 +55,45 @@ module ChromaWave
       # The returned canvas may therefore be smaller than +width+ x +height+
       # if the rectangle extends past the edges.
       #
-      # @param x      [Integer] left edge of the crop rectangle
-      # @param y      [Integer] top edge of the crop rectangle
-      # @param width  [Integer] requested width  (must be positive before clipping)
-      # @param height [Integer] requested height (must be positive before clipping)
+      # @param x      [Numeric] left edge of the crop rectangle (rounded to Integer)
+      # @param y      [Numeric] top edge of the crop rectangle (rounded to Integer)
+      # @param width  [Numeric] requested width  (rounded to Integer, must be positive)
+      # @param height [Numeric] requested height (rounded to Integer, must be positive)
       # @return [Canvas] a new canvas containing the cropped pixels
-      # @raise [ArgumentError] if +width+ or +height+ is not positive,
+      # @raise [ArgumentError] if +width+ or +height+ is not a positive Numeric,
       #   or if the clipped region is entirely outside the canvas
       def crop(x:, y:, width:, height:)
-        raise ArgumentError, 'crop width must be a positive Integer' unless width.is_a?(Integer) && width.positive?
-        raise ArgumentError, 'crop height must be a positive Integer' unless height.is_a?(Integer) && height.positive?
+        raise ArgumentError, 'crop width must be a positive Numeric' unless width.is_a?(Numeric) && width.positive?
+        raise ArgumentError, 'crop height must be a positive Numeric' unless height.is_a?(Numeric) && height.positive?
 
-        crop_clipped(x.round, y.round, width, height)
+        crop_clipped(x.round, y.round, width.round, height.round)
       end
 
       private
+
+      # Builds a new Canvas directly from a pre-filled RGBA buffer.
+      #
+      # Bypasses +initialize+'s background-fill step so transforms can
+      # construct the output without writing pixels twice. The buffer is
+      # always duplicated to guarantee isolation from the caller.
+      #
+      # @param w   [Integer] canvas width
+      # @param h   [Integer] canvas height
+      # @param buf [String]  raw RGBA bytes (+w * h * 4+ bytes)
+      # @return [Canvas]
+      # @raise [ArgumentError] if dimensions or buffer size are invalid
+      def build_canvas(w, h, buf)
+        Surface.validate_dimensions!(w, h)
+
+        expected = w * h * BYTES_PER_PIXEL
+        raise ArgumentError, "buffer size #{buf.bytesize} != #{expected}" unless buf.bytesize == expected
+
+        self.class.allocate.tap do |canvas|
+          canvas.instance_variable_set(:@width, w)
+          canvas.instance_variable_set(:@height, h)
+          canvas.instance_variable_set(:@buffer, buf.dup.force_encoding(Encoding::BINARY))
+        end
+      end
 
       # Mirrors left-to-right by reversing pixels within each row.
       #
@@ -117,7 +108,7 @@ module ChromaWave
           out << src.byteslice(row_start, row_bytes).unpack('V*').reverse.pack('V*')
         end
 
-        Canvas.send(:from_buffer, width, height, out)
+        build_canvas(width, height, out)
       end
 
       # Mirrors top-to-bottom by copying rows in reverse order.
@@ -132,7 +123,7 @@ module ChromaWave
           out << src.byteslice(row_y * row_bytes, row_bytes)
         end
 
-        Canvas.send(:from_buffer, width, height, out)
+        build_canvas(width, height, out)
       end
 
       # Resolves uniform-factor scale arguments into +[new_w, new_h]+.
@@ -221,7 +212,7 @@ module ChromaWave
           out << row
         end
 
-        Canvas.send(:from_buffer, new_w, new_h, out)
+        build_canvas(new_w, new_h, out)
       end
 
       # Clips the crop rectangle to canvas bounds and copies rows.
@@ -264,7 +255,7 @@ module ChromaWave
           out << src.byteslice(offset, copy_len)
         end
 
-        Canvas.send(:from_buffer, out_w, out_h, out)
+        build_canvas(out_w, out_h, out)
       end
     end
   end

--- a/lib/chroma_wave/canvas/transforms.rb
+++ b/lib/chroma_wave/canvas/transforms.rb
@@ -68,7 +68,7 @@ module ChromaWave
         raise ArgumentError, 'crop width must be a positive Numeric' unless width.is_a?(Numeric) && width.positive?
         raise ArgumentError, 'crop height must be a positive Numeric' unless height.is_a?(Numeric) && height.positive?
 
-        crop_clipped(x.round, y.round, width.round, height.round)
+        crop_clipped(x.round, y.round, [width.round, 1].max, [height.round, 1].max)
       end
 
       private
@@ -105,7 +105,7 @@ module ChromaWave
       def flip_horizontal
         src = raw_buffer
         row_bytes = width * BYTES_PER_PIXEL
-        out = String.new(capacity: src.bytesize)
+        out = String.new(capacity: src.bytesize, encoding: Encoding::BINARY)
 
         height.times do |row_y|
           row_start = row_y * row_bytes
@@ -122,7 +122,7 @@ module ChromaWave
       def flip_vertical
         src = raw_buffer
         row_bytes = width * BYTES_PER_PIXEL
-        out = String.new(capacity: src.bytesize)
+        out = String.new(capacity: src.bytesize, encoding: Encoding::BINARY)
 
         (height - 1).downto(0) do |row_y|
           out << src.byteslice(row_y * row_bytes, row_bytes)
@@ -191,7 +191,7 @@ module ChromaWave
       def coerce_scale_dimension!(name, value)
         raise ArgumentError, "#{name} must be a positive Numeric" unless value.is_a?(Numeric) && value.positive?
 
-        value.round
+        [value.round, 1].max
       end
 
       # Nearest-neighbor resampling into a +new_w+ x +new_h+ canvas.
@@ -205,14 +205,14 @@ module ChromaWave
       def scale_nearest(new_w, new_h)
         src = raw_buffer
         src_w = width
-        out = String.new(capacity: new_w * new_h * BYTES_PER_PIXEL)
+        out = String.new(capacity: new_w * new_h * BYTES_PER_PIXEL, encoding: Encoding::BINARY)
 
         # Pre-compute source x byte-offset for each destination column
         x_map = Array.new(new_w) { |dx| (dx * src_w / new_w) * BYTES_PER_PIXEL }
 
         new_h.times do |dy|
           src_row = (dy * height / new_h) * src_w * BYTES_PER_PIXEL
-          row = String.new(capacity: new_w * BYTES_PER_PIXEL)
+          row = String.new(capacity: new_w * BYTES_PER_PIXEL, encoding: Encoding::BINARY)
           x_map.each { |src_x| row << src.byteslice(src_row + src_x, BYTES_PER_PIXEL) }
           out << row
         end
@@ -253,7 +253,7 @@ module ChromaWave
         src = raw_buffer
         src_row_bytes = width * BYTES_PER_PIXEL
         copy_len = out_w * BYTES_PER_PIXEL
-        out = String.new(capacity: out_w * out_h * BYTES_PER_PIXEL)
+        out = String.new(capacity: out_w * out_h * BYTES_PER_PIXEL, encoding: Encoding::BINARY)
 
         (y0...(y0 + out_h)).each do |row_y|
           offset = (row_y * src_row_bytes) + (x0 * BYTES_PER_PIXEL)

--- a/lib/chroma_wave/canvas/transforms.rb
+++ b/lib/chroma_wave/canvas/transforms.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+module ChromaWave
+  class Canvas
+    # Pure-Ruby image transforms for {Canvas}.
+    #
+    # Every method returns a **new** Canvas — the receiver is never mutated.
+    # This makes transforms safe to chain:
+    #
+    #   canvas.crop(x: 10, y: 10, width: 80, height: 60)
+    #         .flip(:horizontal)
+    #         .scale(2.0)
+    #
+    # Included into {Canvas} at the bottom of this file.
+    module Transforms
+      # Hooks the +ClassMethods+ extension when included.
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      # Class-level factory methods added to {Canvas}.
+      module ClassMethods
+        private
+
+        # Builds a Canvas directly from a pre-filled RGBA buffer.
+        #
+        # Bypasses +initialize+'s background-fill step so transforms can
+        # construct the output without writing pixels twice.
+        #
+        # @param width  [Integer] canvas width in pixels
+        # @param height [Integer] canvas height in pixels
+        # @param buf    [String]  raw RGBA bytes (+width * height * 4+ bytes)
+        # @return [Canvas]
+        # @raise [ArgumentError] if dimensions or buffer size are invalid
+        def from_buffer(width, height, buf)
+          raise ArgumentError, 'width must be a positive Integer' unless width.is_a?(Integer) && width.positive?
+          raise ArgumentError, 'height must be a positive Integer' unless height.is_a?(Integer) && height.positive?
+          raise ArgumentError, "width must be <= #{Surface::MAX_DIMENSION}" if width > Surface::MAX_DIMENSION
+          raise ArgumentError, "height must be <= #{Surface::MAX_DIMENSION}" if height > Surface::MAX_DIMENSION
+
+          expected = width * height * BYTES_PER_PIXEL
+          raise ArgumentError, "buffer size #{buf.bytesize} != #{expected}" unless buf.bytesize == expected
+
+          allocate.tap do |canvas|
+            canvas.instance_variable_set(:@width, width)
+            canvas.instance_variable_set(:@height, height)
+            canvas.instance_variable_set(:@buffer, buf.b)
+          end
+        end
+      end
+
+      # Mirrors the canvas horizontally or vertically.
+      #
+      # @param direction [:horizontal, :vertical] the flip axis
+      # @return [Canvas] a new, mirrored canvas
+      # @raise [ArgumentError] if +direction+ is not +:horizontal+ or +:vertical+
+      def flip(direction)
+        case direction
+        when :horizontal then flip_horizontal
+        when :vertical   then flip_vertical
+        else raise ArgumentError, "direction must be :horizontal or :vertical, got #{direction.inspect}"
+        end
+      end
+
+      # Scales the canvas using nearest-neighbor interpolation.
+      #
+      # Accepts either a uniform +factor+ or explicit +width:+/+height:+
+      # keywords. When only one keyword is given, the other dimension is
+      # calculated to preserve the aspect ratio. Output dimensions are
+      # clamped to a minimum of 1.
+      #
+      # @overload scale(factor)
+      #   @param factor [Numeric] uniform scale factor (must be positive)
+      # @overload scale(width:)
+      #   @param width [Integer] target width (aspect ratio preserved)
+      # @overload scale(height:)
+      #   @param height [Integer] target height (aspect ratio preserved)
+      # @overload scale(width:, height:)
+      #   @param width  [Integer] target width
+      #   @param height [Integer] target height
+      # @return [Canvas] a new, scaled canvas
+      # @raise [ArgumentError] on invalid or conflicting arguments
+      def scale(factor = nil, width: nil, height: nil)
+        new_w, new_h = resolve_scale_dimensions(factor, width, height)
+        scale_nearest(new_w, new_h)
+      end
+
+      # Extracts a rectangular sub-region of the canvas.
+      #
+      # The requested rectangle is silently clipped to the canvas bounds.
+      # The returned canvas may therefore be smaller than +width+ x +height+
+      # if the rectangle extends past the edges.
+      #
+      # @param x      [Integer] left edge of the crop rectangle
+      # @param y      [Integer] top edge of the crop rectangle
+      # @param width  [Integer] requested width  (must be positive before clipping)
+      # @param height [Integer] requested height (must be positive before clipping)
+      # @return [Canvas] a new canvas containing the cropped pixels
+      # @raise [ArgumentError] if +width+ or +height+ is not positive,
+      #   or if the clipped region is entirely outside the canvas
+      def crop(x:, y:, width:, height:)
+        raise ArgumentError, 'crop width must be positive' unless width.is_a?(Integer) && width.positive?
+        raise ArgumentError, 'crop height must be positive' unless height.is_a?(Integer) && height.positive?
+
+        crop_clipped(x, y, width, height)
+      end
+
+      private
+
+      # Mirrors left-to-right by reversing pixels within each row.
+      #
+      # @return [Canvas]
+      def flip_horizontal
+        src = raw_buffer
+        row_bytes = width * BYTES_PER_PIXEL
+        out = String.new(capacity: src.bytesize)
+
+        height.times do |row_y|
+          row_start = row_y * row_bytes
+          (width - 1).downto(0) do |col_x|
+            out << src.byteslice(row_start + (col_x * BYTES_PER_PIXEL), BYTES_PER_PIXEL)
+          end
+        end
+
+        Canvas.send(:from_buffer, width, height, out)
+      end
+
+      # Mirrors top-to-bottom by copying rows in reverse order.
+      #
+      # @return [Canvas]
+      def flip_vertical
+        src = raw_buffer
+        row_bytes = width * BYTES_PER_PIXEL
+        out = String.new(capacity: src.bytesize)
+
+        (height - 1).downto(0) do |row_y|
+          out << src.byteslice(row_y * row_bytes, row_bytes)
+        end
+
+        Canvas.send(:from_buffer, width, height, out)
+      end
+
+      # Resolves uniform-factor scale arguments into +[new_w, new_h]+.
+      #
+      # @return [Array(Integer, Integer)]
+      # @raise [ArgumentError] on invalid arguments
+      def resolve_scale_factor(factor, target_w, target_h)
+        raise ArgumentError, 'scale factor must be a positive number' unless factor.is_a?(Numeric) && factor.positive?
+        raise ArgumentError, 'cannot mix positional factor with width:/height: keywords' if target_w || target_h
+
+        [[(width * factor).round, 1].max,
+         [(height * factor).round, 1].max]
+      end
+
+      # Resolves keyword-based scale arguments into +[new_w, new_h]+.
+      #
+      # @return [Array(Integer, Integer)]
+      # @raise [ArgumentError] on invalid arguments
+      def resolve_scale_keywords(target_w, target_h)
+        if target_w && target_h
+          validate_scale_dimension!(:width, target_w)
+          validate_scale_dimension!(:height, target_h)
+          [target_w, target_h]
+        elsif target_w
+          validate_scale_dimension!(:width, target_w)
+          [target_w, [(height * target_w.to_f / width).round, 1].max]
+        elsif target_h
+          validate_scale_dimension!(:height, target_h)
+          [[(width * target_h.to_f / height).round, 1].max, target_h]
+        else
+          raise ArgumentError, 'scale requires a factor or width:/height: keywords'
+        end
+      end
+
+      # Converts the various scale argument forms into +[new_w, new_h]+.
+      #
+      # @return [Array(Integer, Integer)]
+      # @raise [ArgumentError] on invalid or conflicting arguments
+      def resolve_scale_dimensions(factor, target_w, target_h)
+        if factor
+          resolve_scale_factor(factor, target_w, target_h)
+        else
+          resolve_scale_keywords(target_w, target_h)
+        end
+      end
+
+      # Validates a single target dimension for scale.
+      #
+      # @param name [Symbol] :width or :height
+      # @param value [Object] the value to check
+      # @raise [ArgumentError] unless positive Integer
+      def validate_scale_dimension!(name, value)
+        return if value.is_a?(Integer) && value.positive?
+
+        raise ArgumentError, "#{name} must be a positive Integer"
+      end
+
+      # Nearest-neighbor resampling into a +new_w+ x +new_h+ canvas.
+      #
+      # Pre-computes the source-x lookup table to avoid per-pixel division.
+      #
+      # @param new_w [Integer] output width
+      # @param new_h [Integer] output height
+      # @return [Canvas]
+      def scale_nearest(new_w, new_h)
+        src = raw_buffer
+        src_w = width
+        out = String.new(capacity: new_w * new_h * BYTES_PER_PIXEL)
+
+        # Pre-compute source x for each destination column
+        x_map = Array.new(new_w) { |dx| (dx * src_w / new_w) * BYTES_PER_PIXEL }
+
+        new_h.times do |dy|
+          src_row = (dy * height / new_h) * src_w * BYTES_PER_PIXEL
+          new_w.times do |dx|
+            out << src.byteslice(src_row + x_map[dx], BYTES_PER_PIXEL)
+          end
+        end
+
+        Canvas.send(:from_buffer, new_w, new_h, out)
+      end
+
+      # Clips the crop rectangle to canvas bounds and copies rows.
+      #
+      # @param x [Integer] left edge
+      # @param y [Integer] top edge
+      # @param w [Integer] requested width
+      # @param h [Integer] requested height
+      # @return [Canvas]
+      # @raise [ArgumentError] if the clipped region is entirely outside
+      def crop_clipped(x, y, w, h)
+        x0, y0, out_w, out_h = compute_crop_bounds(x, y, w, h)
+        raise ArgumentError, 'crop region is entirely outside the canvas' if out_w <= 0 || out_h <= 0
+
+        copy_crop_rows(x0, y0, out_w, out_h)
+      end
+
+      # Computes the clipped crop bounds as +[x0, y0, out_w, out_h]+.
+      #
+      # @return [Array(Integer, Integer, Integer, Integer)]
+      def compute_crop_bounds(x, y, w, h)
+        x0 = x.clamp(0, width)
+        y0 = y.clamp(0, height)
+        x1 = (x + w).clamp(0, width)
+        y1 = (y + h).clamp(0, height)
+        [x0, y0, x1 - x0, y1 - y0]
+      end
+
+      # Copies rows from the raw buffer for a crop operation.
+      #
+      # @return [Canvas]
+      def copy_crop_rows(x0, y0, out_w, out_h)
+        src = raw_buffer
+        src_row_bytes = width * BYTES_PER_PIXEL
+        copy_len = out_w * BYTES_PER_PIXEL
+        out = String.new(capacity: out_w * out_h * BYTES_PER_PIXEL)
+
+        (y0...(y0 + out_h)).each do |row_y|
+          offset = (row_y * src_row_bytes) + (x0 * BYTES_PER_PIXEL)
+          out << src.byteslice(offset, copy_len)
+        end
+
+        Canvas.send(:from_buffer, out_w, out_h, out)
+      end
+    end
+  end
+end
+
+ChromaWave::Canvas.include(ChromaWave::Canvas::Transforms)

--- a/lib/chroma_wave/canvas/transforms.rb
+++ b/lib/chroma_wave/canvas/transforms.rb
@@ -69,12 +69,12 @@ module ChromaWave
       # @overload scale(factor)
       #   @param factor [Numeric] uniform scale factor (must be positive)
       # @overload scale(width:)
-      #   @param width [Integer] target width (aspect ratio preserved)
+      #   @param width [Numeric] target width, rounded to Integer (aspect ratio preserved)
       # @overload scale(height:)
-      #   @param height [Integer] target height (aspect ratio preserved)
+      #   @param height [Numeric] target height, rounded to Integer (aspect ratio preserved)
       # @overload scale(width:, height:)
-      #   @param width  [Integer] target width
-      #   @param height [Integer] target height
+      #   @param width  [Numeric] target width, rounded to Integer
+      #   @param height [Numeric] target height, rounded to Integer
       # @return [Canvas] a new, scaled canvas
       # @raise [ArgumentError] on invalid or conflicting arguments
       def scale(factor = nil, width: nil, height: nil)
@@ -96,8 +96,8 @@ module ChromaWave
       # @raise [ArgumentError] if +width+ or +height+ is not positive,
       #   or if the clipped region is entirely outside the canvas
       def crop(x:, y:, width:, height:)
-        raise ArgumentError, 'crop width must be positive' unless width.is_a?(Integer) && width.positive?
-        raise ArgumentError, 'crop height must be positive' unless height.is_a?(Integer) && height.positive?
+        raise ArgumentError, 'crop width must be a positive Integer' unless width.is_a?(Integer) && width.positive?
+        raise ArgumentError, 'crop height must be a positive Integer' unless height.is_a?(Integer) && height.positive?
 
         crop_clipped(x.round, y.round, width, height)
       end
@@ -153,15 +153,14 @@ module ChromaWave
       # @raise [ArgumentError] on invalid arguments
       def resolve_scale_keywords(target_w, target_h)
         if target_w && target_h
-          validate_scale_dimension!(:width, target_w)
-          validate_scale_dimension!(:height, target_h)
-          [target_w, target_h]
+          [coerce_scale_dimension!(:width, target_w),
+           coerce_scale_dimension!(:height, target_h)]
         elsif target_w
-          validate_scale_dimension!(:width, target_w)
-          [target_w, [(height * target_w.to_f / width).round, 1].max]
+          w = coerce_scale_dimension!(:width, target_w)
+          [w, [(height * w.to_f / width).round, 1].max]
         elsif target_h
-          validate_scale_dimension!(:height, target_h)
-          [[(width * target_h.to_f / height).round, 1].max, target_h]
+          h = coerce_scale_dimension!(:height, target_h)
+          [[(width * h.to_f / height).round, 1].max, h]
         else
           raise ArgumentError, 'scale requires a factor or width:/height: keywords'
         end
@@ -185,20 +184,24 @@ module ChromaWave
         [new_w, new_h]
       end
 
-      # Validates a single target dimension for scale.
+      # Coerces and validates a single target dimension for scale.
+      #
+      # Accepts Integer or Float (rounded to nearest Integer).
       #
       # @param name [Symbol] :width or :height
-      # @param value [Object] the value to check
-      # @raise [ArgumentError] unless positive Integer
-      def validate_scale_dimension!(name, value)
-        return if value.is_a?(Integer) && value.positive?
+      # @param value [Numeric] the value to coerce and check
+      # @return [Integer] the validated dimension
+      # @raise [ArgumentError] unless a positive Numeric
+      def coerce_scale_dimension!(name, value)
+        raise ArgumentError, "#{name} must be a positive Numeric" unless value.is_a?(Numeric) && value.positive?
 
-        raise ArgumentError, "#{name} must be a positive Integer"
+        value.round
       end
 
       # Nearest-neighbor resampling into a +new_w+ x +new_h+ canvas.
       #
-      # Pre-computes the source-x lookup table to avoid per-pixel division.
+      # Pre-computes the source-x lookup table to avoid per-pixel division,
+      # and builds each output row as a single string before appending.
       #
       # @param new_w [Integer] output width
       # @param new_h [Integer] output height
@@ -208,14 +211,14 @@ module ChromaWave
         src_w = width
         out = String.new(capacity: new_w * new_h * BYTES_PER_PIXEL)
 
-        # Pre-compute source x for each destination column
+        # Pre-compute source x byte-offset for each destination column
         x_map = Array.new(new_w) { |dx| (dx * src_w / new_w) * BYTES_PER_PIXEL }
 
         new_h.times do |dy|
           src_row = (dy * height / new_h) * src_w * BYTES_PER_PIXEL
-          new_w.times do |dx|
-            out << src.byteslice(src_row + x_map[dx], BYTES_PER_PIXEL)
-          end
+          row = String.new(capacity: new_w * BYTES_PER_PIXEL)
+          x_map.each { |src_x| row << src.byteslice(src_row + src_x, BYTES_PER_PIXEL) }
+          out << row
         end
 
         Canvas.send(:from_buffer, new_w, new_h, out)

--- a/lib/chroma_wave/canvas/transforms.rb
+++ b/lib/chroma_wave/canvas/transforms.rb
@@ -33,10 +33,7 @@ module ChromaWave
         # @return [Canvas]
         # @raise [ArgumentError] if dimensions or buffer size are invalid
         def from_buffer(width, height, buf)
-          raise ArgumentError, 'width must be a positive Integer' unless width.is_a?(Integer) && width.positive?
-          raise ArgumentError, 'height must be a positive Integer' unless height.is_a?(Integer) && height.positive?
-          raise ArgumentError, "width must be <= #{Surface::MAX_DIMENSION}" if width > Surface::MAX_DIMENSION
-          raise ArgumentError, "height must be <= #{Surface::MAX_DIMENSION}" if height > Surface::MAX_DIMENSION
+          Surface.validate_dimensions!(width, height)
 
           expected = width * height * BYTES_PER_PIXEL
           raise ArgumentError, "buffer size #{buf.bytesize} != #{expected}" unless buf.bytesize == expected
@@ -44,7 +41,7 @@ module ChromaWave
           allocate.tap do |canvas|
             canvas.instance_variable_set(:@width, width)
             canvas.instance_variable_set(:@height, height)
-            canvas.instance_variable_set(:@buffer, buf.b)
+            canvas.instance_variable_set(:@buffer, buf.encoding == Encoding::BINARY ? buf : buf.b)
           end
         end
       end
@@ -102,7 +99,7 @@ module ChromaWave
         raise ArgumentError, 'crop width must be positive' unless width.is_a?(Integer) && width.positive?
         raise ArgumentError, 'crop height must be positive' unless height.is_a?(Integer) && height.positive?
 
-        crop_clipped(x, y, width, height)
+        crop_clipped(x.round, y.round, width, height)
       end
 
       private
@@ -117,9 +114,7 @@ module ChromaWave
 
         height.times do |row_y|
           row_start = row_y * row_bytes
-          (width - 1).downto(0) do |col_x|
-            out << src.byteslice(row_start + (col_x * BYTES_PER_PIXEL), BYTES_PER_PIXEL)
-          end
+          out << src.byteslice(row_start, row_bytes).unpack('V*').reverse.pack('V*')
         end
 
         Canvas.send(:from_buffer, width, height, out)
@@ -177,11 +172,17 @@ module ChromaWave
       # @return [Array(Integer, Integer)]
       # @raise [ArgumentError] on invalid or conflicting arguments
       def resolve_scale_dimensions(factor, target_w, target_h)
-        if factor
-          resolve_scale_factor(factor, target_w, target_h)
-        else
-          resolve_scale_keywords(target_w, target_h)
-        end
+        new_w, new_h = if factor
+                         resolve_scale_factor(factor, target_w, target_h)
+                       else
+                         resolve_scale_keywords(target_w, target_h)
+                       end
+
+        max = Surface::MAX_DIMENSION
+        raise ArgumentError, "scaled width #{new_w} exceeds maximum dimension #{max}" if new_w > max
+        raise ArgumentError, "scaled height #{new_h} exceeds maximum dimension #{max}" if new_h > max
+
+        [new_w, new_h]
       end
 
       # Validates a single target dimension for scale.

--- a/lib/chroma_wave/surface.rb
+++ b/lib/chroma_wave/surface.rb
@@ -75,6 +75,8 @@ module ChromaWave
       raise ArgumentError, "width must be <= #{MAX_DIMENSION}" if w > MAX_DIMENSION
       raise ArgumentError, "height must be <= #{MAX_DIMENSION}" if h > MAX_DIMENSION
     end
+
+    module_function :validate_dimensions!
   end
 end
 

--- a/spec/chroma_wave/canvas/transforms_spec.rb
+++ b/spec/chroma_wave/canvas/transforms_spec.rb
@@ -668,17 +668,30 @@ RSpec.describe ChromaWave::Canvas::Transforms do
       expect(scaled).not_to equal(flipped)
     end
 
-    it 'flip(:horizontal) then flip(:vertical) is not the same as either alone' do
+    it 'combined horizontal + vertical flips commute' do
       c = canvas(3, 3)
       c.set_pixel(0, 0, red)
 
       hv = c.flip(:horizontal).flip(:vertical)
       vh = c.flip(:vertical).flip(:horizontal)
 
-      # Both result in the pixel at (2,2) — they commute
       expect(hv.get_pixel(2, 2)).to eq(red)
       expect(vh.get_pixel(2, 2)).to eq(red)
       expect(hv).to eq(vh)
+    end
+
+    it 'combined flips differ from either single flip alone' do
+      c = canvas(3, 3)
+      c.set_pixel(0, 0, red)
+
+      h  = c.flip(:horizontal)
+      v  = c.flip(:vertical)
+      hv = h.flip(:vertical)
+
+      expect(h.get_pixel(2, 0)).to eq(red)
+      expect(v.get_pixel(0, 2)).to eq(red)
+      expect(hv).not_to eq(h)
+      expect(hv).not_to eq(v)
     end
   end
 

--- a/spec/chroma_wave/canvas/transforms_spec.rb
+++ b/spec/chroma_wave/canvas/transforms_spec.rb
@@ -370,6 +370,21 @@ RSpec.describe ChromaWave::Canvas::Transforms do
         expect(result.width).to eq(4)
         expect(result.height).to eq(4)
       end
+
+      it 'raises for non-Numeric factor' do
+        c = canvas(2, 2)
+        expect { c.scale('big') }.to raise_error(ArgumentError, /factor/)
+      end
+
+      it 'raises for non-Numeric width: keyword' do
+        c = canvas(2, 2)
+        expect { c.scale(width: '100') }.to raise_error(ArgumentError, /width/)
+      end
+
+      it 'raises for non-Numeric height: keyword' do
+        c = canvas(2, 2)
+        expect { c.scale(height: '100') }.to raise_error(ArgumentError, /height/)
+      end
     end
   end
 
@@ -588,6 +603,30 @@ RSpec.describe ChromaWave::Canvas::Transforms do
         c = canvas(5, 5)
         expect { c.crop(x: 0, y: 10, width: 3, height: 3) }
           .to raise_error(ArgumentError, /outside/)
+      end
+
+      it 'raises for non-Numeric x' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 'a', y: 0, width: 3, height: 3) }
+          .to raise_error(ArgumentError, /x/)
+      end
+
+      it 'raises for non-Numeric y' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 0, y: nil, width: 3, height: 3) }
+          .to raise_error(ArgumentError, /y/)
+      end
+
+      it 'raises for non-Numeric width' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 0, y: 0, width: '5', height: 3) }
+          .to raise_error(ArgumentError, /width/)
+      end
+
+      it 'raises for non-Numeric height' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 0, y: 0, width: 3, height: '3') }
+          .to raise_error(ArgumentError, /height/)
       end
     end
   end

--- a/spec/chroma_wave/canvas/transforms_spec.rb
+++ b/spec/chroma_wave/canvas/transforms_spec.rb
@@ -332,14 +332,14 @@ RSpec.describe ChromaWave::Canvas::Transforms do
         expect { c.scale(2.0, height: 10) }.to raise_error(ArgumentError, /mix/)
       end
 
-      it 'raises for non-positive width: keyword' do
+      it 'raises for zero width: keyword' do
         c = canvas(2, 2)
-        expect { c.scale(width: 0) }.to raise_error(ArgumentError)
+        expect { c.scale(width: 0) }.to raise_error(ArgumentError, /width/)
       end
 
-      it 'raises for non-positive height: keyword' do
+      it 'raises for negative height: keyword' do
         c = canvas(2, 2)
-        expect { c.scale(height: -5) }.to raise_error(ArgumentError)
+        expect { c.scale(height: -5) }.to raise_error(ArgumentError, /height/)
       end
 
       it 'raises when factor produces width exceeding MAX_DIMENSION' do
@@ -357,14 +357,18 @@ RSpec.describe ChromaWave::Canvas::Transforms do
         expect { c.scale(width: 5000) }.to raise_error(ArgumentError, /scaled width.*exceeds maximum/)
       end
 
-      it 'raises for Float width: keyword' do
+      it 'rounds Float width: keyword to nearest Integer' do
         c = canvas(10, 10)
-        expect { c.scale(width: 5.5) }.to raise_error(ArgumentError)
+        result = c.scale(width: 5.5)
+        expect(result.width).to eq(6)
+        expect(result.height).to eq(6)
       end
 
-      it 'raises for Float height: keyword' do
+      it 'rounds Float height: keyword to nearest Integer' do
         c = canvas(10, 10)
-        expect { c.scale(height: 3.7) }.to raise_error(ArgumentError)
+        result = c.scale(height: 3.7)
+        expect(result.width).to eq(4)
+        expect(result.height).to eq(4)
       end
     end
   end

--- a/spec/chroma_wave/canvas/transforms_spec.rb
+++ b/spec/chroma_wave/canvas/transforms_spec.rb
@@ -341,6 +341,31 @@ RSpec.describe ChromaWave::Canvas::Transforms do
         c = canvas(2, 2)
         expect { c.scale(height: -5) }.to raise_error(ArgumentError)
       end
+
+      it 'raises when factor produces width exceeding MAX_DIMENSION' do
+        c = canvas(4096, 1)
+        expect { c.scale(2.0) }.to raise_error(ArgumentError, /scaled width.*exceeds maximum/)
+      end
+
+      it 'raises when factor produces height exceeding MAX_DIMENSION' do
+        c = canvas(1, 4096)
+        expect { c.scale(2.0) }.to raise_error(ArgumentError, /scaled height.*exceeds maximum/)
+      end
+
+      it 'raises when width: keyword exceeds MAX_DIMENSION' do
+        c = canvas(10, 10)
+        expect { c.scale(width: 5000) }.to raise_error(ArgumentError, /scaled width.*exceeds maximum/)
+      end
+
+      it 'raises for Float width: keyword' do
+        c = canvas(10, 10)
+        expect { c.scale(width: 5.5) }.to raise_error(ArgumentError)
+      end
+
+      it 'raises for Float height: keyword' do
+        c = canvas(10, 10)
+        expect { c.scale(height: 3.7) }.to raise_error(ArgumentError)
+      end
     end
   end
 
@@ -469,6 +494,49 @@ RSpec.describe ChromaWave::Canvas::Transforms do
       end
     end
 
+    describe 'float x/y coercion' do
+      it 'rounds x: 2.6 to 3' do
+        c = canvas(10, 10)
+        c.set_pixel(3, 0, red)
+
+        result = c.crop(x: 2.6, y: 0, width: 2, height: 1)
+
+        expect(result.get_pixel(0, 0)).to eq(red)
+      end
+
+      it 'rounds y: 2.7 to 3' do
+        c = canvas(10, 10)
+        c.set_pixel(0, 3, red)
+
+        result = c.crop(x: 0, y: 2.7, width: 1, height: 2)
+
+        expect(result.get_pixel(0, 0)).to eq(red)
+      end
+
+      it 'rounds x: 2.3 to 2' do
+        c = canvas(10, 10)
+        c.set_pixel(2, 0, red)
+
+        result = c.crop(x: 2.3, y: 0, width: 2, height: 1)
+
+        expect(result.get_pixel(0, 0)).to eq(red)
+      end
+    end
+
+    describe 'exact boundary' do
+      it 'raises when x equals canvas width' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 5, y: 0, width: 1, height: 1) }
+          .to raise_error(ArgumentError, /outside/)
+      end
+
+      it 'raises when y equals canvas height' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 0, y: 5, width: 1, height: 1) }
+          .to raise_error(ArgumentError, /outside/)
+      end
+    end
+
     describe 'validation' do
       it 'raises for zero width' do
         c = canvas(5, 5)
@@ -556,6 +624,37 @@ RSpec.describe ChromaWave::Canvas::Transforms do
       expect(hv.get_pixel(2, 2)).to eq(red)
       expect(vh.get_pixel(2, 2)).to eq(red)
       expect(hv).to eq(vh)
+    end
+  end
+
+  # ── from_buffer (via transforms) ──────────────────────────────────────
+
+  describe 'from_buffer internals' do
+    let(:bpp) { ChromaWave::Canvas::BYTES_PER_PIXEL }
+
+    it 'rejects a buffer with wrong byte size' do
+      bad_buf = "\x00" * 10
+      expect { ChromaWave::Canvas.send(:from_buffer, 3, 3, bad_buf) }
+        .to raise_error(ArgumentError, /buffer size/)
+    end
+
+    it 'rejects zero width' do
+      expect { ChromaWave::Canvas.send(:from_buffer, 0, 1, ''.b) }
+        .to raise_error(ArgumentError, /width/)
+    end
+
+    it 'rejects zero height' do
+      expect { ChromaWave::Canvas.send(:from_buffer, 1, 0, ''.b) }
+        .to raise_error(ArgumentError, /height/)
+    end
+
+    it 'accepts a correctly-sized buffer and produces a valid canvas' do
+      buf = ("\xFF\x00\x00\xFF" * 6).b
+      result = ChromaWave::Canvas.send(:from_buffer, 3, 2, buf)
+
+      expect(result.width).to eq(3)
+      expect(result.height).to eq(2)
+      expect(result.get_pixel(0, 0)).to eq(red)
     end
   end
 end

--- a/spec/chroma_wave/canvas/transforms_spec.rb
+++ b/spec/chroma_wave/canvas/transforms_spec.rb
@@ -1,0 +1,561 @@
+# frozen_string_literal: true
+
+RSpec.describe ChromaWave::Canvas::Transforms do
+  let(:red)   { ChromaWave::Color::RED }
+  let(:green) { ChromaWave::Color::GREEN }
+  let(:blue)  { ChromaWave::Color::BLUE }
+  let(:black) { ChromaWave::Color::BLACK }
+  let(:white) { ChromaWave::Color::WHITE }
+
+  # Helper: build a small canvas with individually-addressed pixels.
+  # Yields the canvas so callers can paint it.
+  def canvas(width, height, background: white)
+    ChromaWave::Canvas.new(width: width, height: height, background: background)
+  end
+
+  # ── flip ───────────────────────────────────────────────────────────────
+
+  describe '#flip' do
+    describe ':horizontal' do
+      it 'mirrors pixels left-to-right on a 3x2 canvas' do
+        c = canvas(3, 2)
+        c.set_pixel(0, 0, red)
+        c.set_pixel(1, 0, green)
+        c.set_pixel(2, 0, blue)
+
+        result = c.flip(:horizontal)
+
+        expect(result.get_pixel(0, 0)).to eq(blue)
+        expect(result.get_pixel(1, 0)).to eq(green)
+        expect(result.get_pixel(2, 0)).to eq(red)
+      end
+
+      it 'preserves row positions (only reverses within rows)' do
+        c = canvas(2, 2)
+        c.set_pixel(0, 0, red)
+        c.set_pixel(1, 1, blue)
+
+        result = c.flip(:horizontal)
+
+        expect(result.get_pixel(1, 0)).to eq(red)
+        expect(result.get_pixel(0, 1)).to eq(blue)
+      end
+
+      it 'preserves dimensions' do
+        c = canvas(5, 3)
+        result = c.flip(:horizontal)
+        expect(result.width).to eq(5)
+        expect(result.height).to eq(3)
+      end
+
+      it 'does not mutate the original' do
+        c = canvas(2, 1)
+        c.set_pixel(0, 0, red)
+        c.flip(:horizontal)
+        expect(c.get_pixel(0, 0)).to eq(red)
+      end
+
+      it 'double-flip is identity' do
+        c = canvas(3, 2)
+        c.set_pixel(0, 0, red)
+        c.set_pixel(2, 1, blue)
+
+        result = c.flip(:horizontal).flip(:horizontal)
+
+        expect(result).to eq(c)
+      end
+
+      it 'works on a 1x1 canvas' do
+        c = canvas(1, 1, background: red)
+        result = c.flip(:horizontal)
+        expect(result.get_pixel(0, 0)).to eq(red)
+      end
+
+      it 'works on a single-row canvas' do
+        c = canvas(4, 1)
+        c.set_pixel(0, 0, red)
+        c.set_pixel(3, 0, blue)
+
+        result = c.flip(:horizontal)
+
+        expect(result.get_pixel(0, 0)).to eq(blue)
+        expect(result.get_pixel(3, 0)).to eq(red)
+      end
+
+      it 'works on a single-column canvas' do
+        c = canvas(1, 3)
+        c.set_pixel(0, 0, red)
+        c.set_pixel(0, 2, blue)
+
+        result = c.flip(:horizontal)
+
+        # Single column: horizontal flip changes nothing
+        expect(result.get_pixel(0, 0)).to eq(red)
+        expect(result.get_pixel(0, 2)).to eq(blue)
+      end
+    end
+
+    describe ':vertical' do
+      it 'mirrors rows top-to-bottom on a 3x2 canvas' do
+        c = canvas(3, 2)
+        c.set_pixel(0, 0, red)
+        c.set_pixel(0, 1, blue)
+
+        result = c.flip(:vertical)
+
+        expect(result.get_pixel(0, 0)).to eq(blue)
+        expect(result.get_pixel(0, 1)).to eq(red)
+      end
+
+      it 'preserves column positions (only reverses row order)' do
+        c = canvas(2, 3)
+        c.set_pixel(1, 0, red)
+        c.set_pixel(0, 2, blue)
+
+        result = c.flip(:vertical)
+
+        expect(result.get_pixel(1, 2)).to eq(red)
+        expect(result.get_pixel(0, 0)).to eq(blue)
+      end
+
+      it 'preserves dimensions' do
+        c = canvas(3, 5)
+        result = c.flip(:vertical)
+        expect(result.width).to eq(3)
+        expect(result.height).to eq(5)
+      end
+
+      it 'does not mutate the original' do
+        c = canvas(1, 2)
+        c.set_pixel(0, 0, red)
+        c.flip(:vertical)
+        expect(c.get_pixel(0, 0)).to eq(red)
+      end
+
+      it 'double-flip is identity' do
+        c = canvas(2, 3)
+        c.set_pixel(0, 0, red)
+        c.set_pixel(1, 2, blue)
+
+        result = c.flip(:vertical).flip(:vertical)
+
+        expect(result).to eq(c)
+      end
+
+      it 'works on a 1x1 canvas' do
+        c = canvas(1, 1, background: blue)
+        result = c.flip(:vertical)
+        expect(result.get_pixel(0, 0)).to eq(blue)
+      end
+
+      it 'works on a single-row canvas' do
+        c = canvas(3, 1)
+        c.set_pixel(0, 0, red)
+
+        result = c.flip(:vertical)
+
+        # Single row: vertical flip changes nothing
+        expect(result.get_pixel(0, 0)).to eq(red)
+      end
+
+      it 'works on a single-column canvas' do
+        c = canvas(1, 4)
+        c.set_pixel(0, 0, red)
+        c.set_pixel(0, 3, blue)
+
+        result = c.flip(:vertical)
+
+        expect(result.get_pixel(0, 0)).to eq(blue)
+        expect(result.get_pixel(0, 3)).to eq(red)
+      end
+    end
+
+    describe 'validation' do
+      it 'raises ArgumentError for invalid direction' do
+        c = canvas(2, 2)
+        expect { c.flip(:diagonal) }.to raise_error(ArgumentError, /direction/)
+      end
+
+      it 'raises ArgumentError for nil direction' do
+        c = canvas(2, 2)
+        expect { c.flip(nil) }.to raise_error(ArgumentError, /direction/)
+      end
+    end
+  end
+
+  # ── scale ──────────────────────────────────────────────────────────────
+
+  describe '#scale' do
+    describe 'with uniform factor' do
+      it 'doubles a 2x2 canvas to 4x4 with correct dimensions' do
+        c = canvas(2, 2)
+        c.set_pixel(0, 0, red)
+        c.set_pixel(1, 0, green)
+        c.set_pixel(0, 1, blue)
+        c.set_pixel(1, 1, black)
+
+        result = c.scale(2.0)
+
+        expect(result.width).to eq(4)
+        expect(result.height).to eq(4)
+      end
+
+      it 'maps each source pixel to a 2x2 block when doubled' do
+        c = canvas(2, 2)
+        colors = { [0, 0] => red, [1, 0] => green, [0, 1] => blue, [1, 1] => black }
+        colors.each { |(x, y), color| c.set_pixel(x, y, color) }
+
+        result = c.scale(2.0)
+
+        # Verify each source pixel's corresponding block corner in the output
+        colors.each do |(sx, sy), color|
+          expect(result.get_pixel(sx * 2, sy * 2)).to eq(color)
+          expect(result.get_pixel((sx * 2) + 1, (sy * 2) + 1)).to eq(color)
+        end
+      end
+
+      it 'halves a 4x4 canvas to 2x2 with sampled pixels' do
+        c = canvas(4, 4)
+        # Paint 2x2 blocks
+        [0, 1].each { |x| [0, 1].each { |y| c.set_pixel(x, y, red) } }
+        [2, 3].each { |x| [0, 1].each { |y| c.set_pixel(x, y, blue) } }
+
+        result = c.scale(0.5)
+
+        expect(result.width).to eq(2)
+        expect(result.height).to eq(2)
+        expect(result.get_pixel(0, 0)).to eq(red)
+        expect(result.get_pixel(1, 0)).to eq(blue)
+      end
+
+      it 'scale(1.0) produces an identical copy' do
+        c = canvas(3, 3)
+        c.set_pixel(1, 1, red)
+
+        result = c.scale(1.0)
+
+        expect(result).to eq(c)
+        expect(result).not_to equal(c)
+      end
+
+      it 'clamps dimensions to a minimum of 1' do
+        c = canvas(2, 2, background: red)
+        result = c.scale(0.001)
+        expect(result.width).to eq(1)
+        expect(result.height).to eq(1)
+        expect(result.get_pixel(0, 0)).to eq(red)
+      end
+
+      it 'does not mutate the original' do
+        c = canvas(2, 2, background: red)
+        c.scale(2.0)
+        expect(c.width).to eq(2)
+        expect(c.height).to eq(2)
+      end
+    end
+
+    describe 'with width: keyword' do
+      it 'scales to target width preserving aspect ratio' do
+        c = canvas(100, 50)
+        result = c.scale(width: 200)
+        expect(result.width).to eq(200)
+        expect(result.height).to eq(100)
+      end
+
+      it 'clamps computed height to minimum of 1' do
+        c = canvas(100, 1)
+        result = c.scale(width: 2)
+        expect(result.width).to eq(2)
+        expect(result.height).to be >= 1
+      end
+    end
+
+    describe 'with height: keyword' do
+      it 'scales to target height preserving aspect ratio' do
+        c = canvas(100, 50)
+        result = c.scale(height: 100)
+        expect(result.width).to eq(200)
+        expect(result.height).to eq(100)
+      end
+
+      it 'clamps computed width to minimum of 1' do
+        c = canvas(1, 100)
+        result = c.scale(height: 2)
+        expect(result.height).to eq(2)
+        expect(result.width).to be >= 1
+      end
+    end
+
+    describe 'with width: and height: keywords' do
+      it 'scales to exact dimensions' do
+        c = canvas(10, 10)
+        result = c.scale(width: 30, height: 20)
+        expect(result.width).to eq(30)
+        expect(result.height).to eq(20)
+      end
+    end
+
+    describe 'with 1x1 canvas' do
+      it 'scales up to NxN' do
+        c = canvas(1, 1, background: red)
+        result = c.scale(5.0)
+        expect(result.width).to eq(5)
+        expect(result.height).to eq(5)
+        expect(result.get_pixel(0, 0)).to eq(red)
+        expect(result.get_pixel(4, 4)).to eq(red)
+      end
+    end
+
+    describe 'validation' do
+      it 'raises for zero factor' do
+        c = canvas(2, 2)
+        expect { c.scale(0) }.to raise_error(ArgumentError, /factor/)
+      end
+
+      it 'raises for negative factor' do
+        c = canvas(2, 2)
+        expect { c.scale(-1.0) }.to raise_error(ArgumentError, /factor/)
+      end
+
+      it 'raises with no arguments' do
+        c = canvas(2, 2)
+        expect { c.scale }.to raise_error(ArgumentError)
+      end
+
+      it 'raises when mixing factor with width: keyword' do
+        c = canvas(2, 2)
+        expect { c.scale(2.0, width: 10) }.to raise_error(ArgumentError, /mix/)
+      end
+
+      it 'raises when mixing factor with height: keyword' do
+        c = canvas(2, 2)
+        expect { c.scale(2.0, height: 10) }.to raise_error(ArgumentError, /mix/)
+      end
+
+      it 'raises for non-positive width: keyword' do
+        c = canvas(2, 2)
+        expect { c.scale(width: 0) }.to raise_error(ArgumentError)
+      end
+
+      it 'raises for non-positive height: keyword' do
+        c = canvas(2, 2)
+        expect { c.scale(height: -5) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  # ── crop ───────────────────────────────────────────────────────────────
+
+  describe '#crop' do
+    it 'extracts an in-bounds sub-region' do
+      c = canvas(10, 10)
+      c.set_pixel(3, 3, red)
+      c.set_pixel(6, 6, blue)
+
+      result = c.crop(x: 2, y: 2, width: 6, height: 6)
+
+      expect(result.width).to eq(6)
+      expect(result.height).to eq(6)
+      expect(result.get_pixel(1, 1)).to eq(red)  # (3,3) → (1,1) in cropped
+      expect(result.get_pixel(4, 4)).to eq(blue) # (6,6) → (4,4) in cropped
+    end
+
+    it 'crop of full canvas is an identical copy' do
+      c = canvas(5, 5, background: red)
+      c.set_pixel(2, 2, blue)
+
+      result = c.crop(x: 0, y: 0, width: 5, height: 5)
+
+      expect(result).to eq(c)
+      expect(result).not_to equal(c)
+    end
+
+    it 'does not mutate the original' do
+      c = canvas(5, 5, background: red)
+      c.crop(x: 1, y: 1, width: 3, height: 3)
+      expect(c.width).to eq(5)
+      expect(c.height).to eq(5)
+      expect(c.get_pixel(0, 0)).to eq(red)
+    end
+
+    describe 'silent clipping' do
+      it 'clips when x is negative' do
+        c = canvas(10, 10)
+        c.set_pixel(0, 0, red)
+        c.set_pixel(2, 0, blue)
+
+        result = c.crop(x: -2, y: 0, width: 5, height: 2)
+
+        # Clipped to x: 0..3, so width = 3
+        expect(result.width).to eq(3)
+        expect(result.height).to eq(2)
+        expect(result.get_pixel(0, 0)).to eq(red)
+        expect(result.get_pixel(2, 0)).to eq(blue)
+      end
+
+      it 'clips when y is negative' do
+        c = canvas(10, 10)
+        c.set_pixel(0, 0, red)
+
+        result = c.crop(x: 0, y: -3, width: 2, height: 5)
+
+        expect(result.width).to eq(2)
+        expect(result.height).to eq(2)
+        expect(result.get_pixel(0, 0)).to eq(red)
+      end
+
+      it 'clips when width extends past right edge' do
+        c = canvas(10, 10)
+        c.set_pixel(9, 0, red)
+
+        result = c.crop(x: 8, y: 0, width: 5, height: 2)
+
+        expect(result.width).to eq(2)
+        expect(result.height).to eq(2)
+        expect(result.get_pixel(1, 0)).to eq(red)
+      end
+
+      it 'clips when height extends past bottom edge' do
+        c = canvas(10, 10)
+        c.set_pixel(0, 9, red)
+
+        result = c.crop(x: 0, y: 8, width: 2, height: 5)
+
+        expect(result.width).to eq(2)
+        expect(result.height).to eq(2)
+        expect(result.get_pixel(0, 1)).to eq(red)
+      end
+
+      it 'clips on all four sides simultaneously' do
+        c = canvas(5, 5, background: red)
+
+        result = c.crop(x: -2, y: -2, width: 9, height: 9)
+
+        expect(result.width).to eq(5)
+        expect(result.height).to eq(5)
+        expect(result).to eq(c)
+      end
+    end
+
+    describe 'edge cases' do
+      it 'works on a 1x1 canvas' do
+        c = canvas(1, 1, background: red)
+        result = c.crop(x: 0, y: 0, width: 1, height: 1)
+        expect(result.width).to eq(1)
+        expect(result.height).to eq(1)
+        expect(result.get_pixel(0, 0)).to eq(red)
+      end
+
+      it 'extracts a single-row crop' do
+        c = canvas(5, 5)
+        c.set_pixel(2, 2, red)
+
+        result = c.crop(x: 0, y: 2, width: 5, height: 1)
+
+        expect(result.width).to eq(5)
+        expect(result.height).to eq(1)
+        expect(result.get_pixel(2, 0)).to eq(red)
+      end
+
+      it 'extracts a single-column crop' do
+        c = canvas(5, 5)
+        c.set_pixel(2, 3, red)
+
+        result = c.crop(x: 2, y: 0, width: 1, height: 5)
+
+        expect(result.width).to eq(1)
+        expect(result.height).to eq(5)
+        expect(result.get_pixel(0, 3)).to eq(red)
+      end
+    end
+
+    describe 'validation' do
+      it 'raises for zero width' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 0, y: 0, width: 0, height: 3) }
+          .to raise_error(ArgumentError, /width/)
+      end
+
+      it 'raises for negative width' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 0, y: 0, width: -1, height: 3) }
+          .to raise_error(ArgumentError, /width/)
+      end
+
+      it 'raises for zero height' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 0, y: 0, width: 3, height: 0) }
+          .to raise_error(ArgumentError, /height/)
+      end
+
+      it 'raises for negative height' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 0, y: 0, width: 3, height: -1) }
+          .to raise_error(ArgumentError, /height/)
+      end
+
+      it 'raises when clipped region is entirely outside (right of canvas)' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 10, y: 0, width: 3, height: 3) }
+          .to raise_error(ArgumentError, /outside/)
+      end
+
+      it 'raises when clipped region is entirely outside (below canvas)' do
+        c = canvas(5, 5)
+        expect { c.crop(x: 0, y: 10, width: 3, height: 3) }
+          .to raise_error(ArgumentError, /outside/)
+      end
+    end
+  end
+
+  # ── chaining ───────────────────────────────────────────────────────────
+
+  describe 'chaining transforms' do
+    it 'crop → flip → scale produces correct result' do
+      c = canvas(10, 10)
+      # Paint a marker at (1,1)
+      c.set_pixel(1, 1, red)
+
+      result = c.crop(x: 0, y: 0, width: 5, height: 5)
+                .flip(:horizontal)
+                .scale(2.0)
+
+      expect(result.width).to eq(10)
+      expect(result.height).to eq(10)
+
+      # (1,1) in 5x5 crop → (3,1) after h-flip → (6,2)/(7,3) in 2x scale
+      expect(result.get_pixel(6, 2)).to eq(red)
+      expect(result.get_pixel(7, 3)).to eq(red)
+    end
+
+    it 'each step returns a new Canvas' do
+      c = canvas(4, 4, background: red)
+
+      cropped = c.crop(x: 0, y: 0, width: 2, height: 2)
+      flipped = cropped.flip(:vertical)
+      scaled  = flipped.scale(2.0)
+
+      expect(cropped).to be_a(ChromaWave::Canvas)
+      expect(flipped).to be_a(ChromaWave::Canvas)
+      expect(scaled).to be_a(ChromaWave::Canvas)
+
+      # All distinct objects
+      expect(cropped).not_to equal(c)
+      expect(flipped).not_to equal(cropped)
+      expect(scaled).not_to equal(flipped)
+    end
+
+    it 'flip(:horizontal) then flip(:vertical) is not the same as either alone' do
+      c = canvas(3, 3)
+      c.set_pixel(0, 0, red)
+
+      hv = c.flip(:horizontal).flip(:vertical)
+      vh = c.flip(:vertical).flip(:horizontal)
+
+      # Both result in the pixel at (2,2) — they commute
+      expect(hv.get_pixel(2, 2)).to eq(red)
+      expect(vh.get_pixel(2, 2)).to eq(red)
+      expect(hv).to eq(vh)
+    end
+  end
+end

--- a/spec/chroma_wave/canvas/transforms_spec.rb
+++ b/spec/chroma_wave/canvas/transforms_spec.rb
@@ -498,7 +498,7 @@ RSpec.describe ChromaWave::Canvas::Transforms do
       end
     end
 
-    describe 'float x/y coercion' do
+    describe 'float coercion' do
       it 'rounds x: 2.6 to 3' do
         c = canvas(10, 10)
         c.set_pixel(3, 0, red)
@@ -524,6 +524,18 @@ RSpec.describe ChromaWave::Canvas::Transforms do
         result = c.crop(x: 2.3, y: 0, width: 2, height: 1)
 
         expect(result.get_pixel(0, 0)).to eq(red)
+      end
+
+      it 'rounds Float width: 3.7 to 4' do
+        c = canvas(10, 10)
+        result = c.crop(x: 0, y: 0, width: 3.7, height: 2)
+        expect(result.width).to eq(4)
+      end
+
+      it 'rounds Float height: 2.3 to 2' do
+        c = canvas(10, 10)
+        result = c.crop(x: 0, y: 0, width: 3, height: 2.3)
+        expect(result.height).to eq(2)
       end
     end
 
@@ -631,30 +643,24 @@ RSpec.describe ChromaWave::Canvas::Transforms do
     end
   end
 
-  # ── from_buffer (via transforms) ──────────────────────────────────────
+  # ── build_canvas (buffer isolation) ──────────────────────────────────
 
-  describe 'from_buffer internals' do
-    let(:bpp) { ChromaWave::Canvas::BYTES_PER_PIXEL }
+  describe 'build_canvas buffer isolation' do
+    it 'transform output is independent of any shared buffer state' do
+      c = canvas(2, 1)
+      c.set_pixel(0, 0, red)
+      c.set_pixel(1, 0, blue)
 
-    it 'rejects a buffer with wrong byte size' do
-      bad_buf = "\x00" * 10
-      expect { ChromaWave::Canvas.send(:from_buffer, 3, 3, bad_buf) }
-        .to raise_error(ArgumentError, /buffer size/)
+      flipped = c.flip(:horizontal)
+
+      # Mutating the original should not affect the flipped copy
+      c.set_pixel(0, 0, green)
+      expect(flipped.get_pixel(1, 0)).to eq(red)
     end
 
-    it 'rejects zero width' do
-      expect { ChromaWave::Canvas.send(:from_buffer, 0, 1, ''.b) }
-        .to raise_error(ArgumentError, /width/)
-    end
-
-    it 'rejects zero height' do
-      expect { ChromaWave::Canvas.send(:from_buffer, 1, 0, ''.b) }
-        .to raise_error(ArgumentError, /height/)
-    end
-
-    it 'accepts a correctly-sized buffer and produces a valid canvas' do
-      buf = ("\xFF\x00\x00\xFF" * 6).b
-      result = ChromaWave::Canvas.send(:from_buffer, 3, 2, buf)
+    it 'scale produces a canvas with valid dimensions and pixels' do
+      c = canvas(3, 2, background: red)
+      result = c.scale(1.0)
 
       expect(result.width).to eq(3)
       expect(result.height).to eq(2)

--- a/spec/chroma_wave/canvas/transforms_spec.rb
+++ b/spec/chroma_wave/canvas/transforms_spec.rb
@@ -376,6 +376,11 @@ RSpec.describe ChromaWave::Canvas::Transforms do
         expect { c.scale('big') }.to raise_error(ArgumentError, /factor/)
       end
 
+      it 'raises for false factor instead of falling through to keyword path' do
+        c = canvas(2, 2)
+        expect { c.scale(false) }.to raise_error(ArgumentError, /factor/)
+      end
+
       it 'raises for non-Numeric width: keyword' do
         c = canvas(2, 2)
         expect { c.scale(width: '100') }.to raise_error(ArgumentError, /width/)


### PR DESCRIPTION
## Summary

Adds pure-Ruby geometric transforms to `Canvas` — `#flip`, `#scale`, and `#crop` — as a composable, immutable API. Every method returns a new `Canvas`, making transforms safe to chain:

```ruby
canvas.crop(x: 10, y: 10, width: 80, height: 60)
      .flip(:horizontal)
      .scale(2.0)
```

These transforms are foundational for preparing content for e-paper display rendering — flipping for hardware orientation, scaling for resolution adaptation, and cropping for region extraction.

## Changes

- **`lib/chroma_wave/canvas/transforms.rb`** — New `Transforms` module with:
  - `#flip(:horizontal | :vertical)` — pixel mirroring using `unpack('V*').reverse.pack('V*')` for horizontal and row-copy reversal for vertical
  - `#scale(factor)` / `#scale(width:, height:)` — nearest-neighbor resampling with pre-computed x-offset lookup table; supports uniform factor, single-axis with aspect ratio preservation, or explicit width+height
  - `#crop(x:, y:, width:, height:)` — sub-region extraction with silent clipping to canvas bounds; Float coordinates rounded to Integer
  - Private `build_canvas` helper that constructs a Canvas from a pre-filled RGBA buffer, bypassing `initialize`'s background-fill to avoid double-writes
- **`lib/chroma_wave/canvas.rb`** — Added `require_relative 'canvas/transforms'`
- **`lib/chroma_wave/surface.rb`** — Exposed `validate_dimensions!` as `module_function` for use by `build_canvas`
- **`spec/chroma_wave/canvas/transforms_spec.rb`** — 78 specs covering all three transforms

## Type of Change

- [x] `feat:` New feature (Canvas transform API)
- [x] `test:` New test coverage (78 specs)
- [x] `refactor:` Internal helper methods for clean decomposition

## Testing

78 RSpec examples, 0 failures. Coverage includes:

- **Happy paths** — flip both directions, scale up/down/uniform/keyword, crop in-bounds
- **Edge cases** — 1x1 canvas, single-row, single-column, extreme downscale to 1x1, boundary-exact coordinates
- **Validation** — bad types, negative/zero values, conflicting arguments, MAX_DIMENSION overflow
- **Float coercion** — rounding behavior for all Numeric parameters
- **Clipping** — negative x/y, overflow past edges, all-four-sides simultaneous clip, entirely-outside rejection
- **Immutability** — originals are never mutated, double-flip is identity
- **Chaining** — multi-step crop→flip→scale produces correct results, each step returns a distinct Canvas
- **Buffer isolation** — mutating original after transform does not affect output

```
78 examples, 0 failures
Finished in 0.036 seconds
2 files inspected, no offenses detected (rubocop)
```

## Notes for Reviewers

- `build_canvas` uses `self.class.allocate` + `instance_variable_set` to bypass `initialize`. This is intentional — it avoids the background-fill write so transform output pixels are written exactly once.
- `flip_horizontal` treats 4-byte RGBA pixels as uint32 via `unpack('V*')` — this is endian-safe because `V` (little-endian) round-trips without altering byte order within pixels.
- `scale_nearest` uses integer division (`dx * src_w / new_w`) for nearest-neighbor mapping. Truncation gives floor behavior, which is standard for this interpolation method.
- `raw_buffer` (existing public method) is used for zero-copy read access to source pixels. All transforms capture it in a local before writing to a separate output buffer.
- Silent clipping in `crop` is a deliberate design choice — it matches the behavior users expect from image libraries and avoids forcing callers to pre-clamp coordinates.

## How this Makes You Feel

### 🪞✂️📐🖼️✨