### PR TITLE
feat: Add QR code and barcode rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,6 @@ gem 'rdoc', '~> 7.2'
 # Optional: image loading support (requires libvips system library)
 gem 'ruby-vips', '~> 2.2', require: false
 
-gem 'barby',   '~> 0.7'
-gem 'rqrcode', '~> 3.0'
+# Optional: QR code and barcode rendering
+gem 'barby',   '~> 0.7', require: false
+gem 'rqrcode', '~> 3.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,6 @@ gem 'rdoc', '~> 7.2'
 
 # Optional: image loading support (requires libvips system library)
 gem 'ruby-vips', '~> 2.2', require: false
+
+gem 'barby',   '~> 0.7'
+gem 'rqrcode', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,15 @@ PATH
   remote: .
   specs:
     chroma_wave (0.1.0)
+      barby (~> 0.7)
+      rqrcode (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    barby (0.7.0)
+    chunky_png (1.4.0)
     date (3.5.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
@@ -49,6 +53,10 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
+    rqrcode (3.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 2.0)
+    rqrcode_core (2.1.0)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -102,12 +110,14 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  barby (~> 0.7)
   chroma_wave!
   hanna-nouveau (~> 1.5)
   irb
   rake (~> 13.0)
   rake-compiler
   rdoc (~> 7.2)
+  rqrcode (~> 3.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
   rubocop-rake (~> 0.7.1)
@@ -117,7 +127,9 @@ DEPENDENCIES
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  barby (0.7.0) sha256=8dbc7c0c320e596135d97929c0df77f969e9f9c955a157cf6749c05b44dae213
   chroma_wave (0.1.0)
+  chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
@@ -144,6 +156,8 @@ CHECKSUMS
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rqrcode (3.2.0) sha256=64c1494ca6bb67d731330f38b50e3fd09eeab4f5dcd04b608e21218d1d0b9542
+  rqrcode_core (2.1.0) sha256=f303b85df89c1b8fc5ee8dc19808c9dc4330e6329b660d99d4a8cbb36ca13051
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ PATH
   remote: .
   specs:
     chroma_wave (0.1.0)
-      barby (~> 0.7)
-      rqrcode (~> 3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/chroma_wave.gemspec
+++ b/chroma_wave.gemspec
@@ -35,8 +35,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.extensions = ['ext/chroma_wave/extconf.rb']
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency 'barby',   '~> 0.7'
+  spec.add_dependency 'rqrcode', '~> 3.0'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/chroma_wave.gemspec
+++ b/chroma_wave.gemspec
@@ -35,9 +35,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.extensions = ['ext/chroma_wave/extconf.rb']
 
-  spec.add_dependency 'barby',   '~> 0.7'
-  spec.add_dependency 'rqrcode', '~> 3.0'
-
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
 end

--- a/lib/chroma_wave.rb
+++ b/lib/chroma_wave.rb
@@ -27,6 +27,7 @@ ChromaWave::Layer.include(ChromaWave::Drawing::Text)
 require_relative 'chroma_wave/text_metrics' # TextMetrics value type (used by Font#measure)
 require_relative 'chroma_wave/font'         # Font loading, glyph measurement (requires Surface)
 require_relative 'chroma_wave/icon_font'    # IconFont < Font with glyph name registry
+require_relative 'chroma_wave/qr'           # QR code measurement utilities
 require_relative 'chroma_wave/image'        # Optional vips-backed image loading
 require_relative 'chroma_wave/device'       # Reopens C class, adds Mutex + open/close lifecycle
 require_relative 'chroma_wave/dither'       # Dithering strategies (loaded before Renderer)

--- a/lib/chroma_wave.rb
+++ b/lib/chroma_wave.rb
@@ -28,6 +28,7 @@ require_relative 'chroma_wave/text_metrics' # TextMetrics value type (used by Fo
 require_relative 'chroma_wave/font'         # Font loading, glyph measurement (requires Surface)
 require_relative 'chroma_wave/icon_font'    # IconFont < Font with glyph name registry
 require_relative 'chroma_wave/qr'           # QR code measurement utilities
+require_relative 'chroma_wave/barcode'      # Barcode construction and measurement
 require_relative 'chroma_wave/image'        # Optional vips-backed image loading
 require_relative 'chroma_wave/device'       # Reopens C class, adds Mutex + open/close lifecycle
 require_relative 'chroma_wave/dither'       # Dithering strategies (loaded before Renderer)

--- a/lib/chroma_wave/barcode.rb
+++ b/lib/chroma_wave/barcode.rb
@@ -12,6 +12,12 @@ module ChromaWave
   #   metrics.width  # => total pixel width of the rendered barcode
   #   metrics.height # => total pixel height (bars only, unless include_text)
   module Barcode
+    # Pixel gap between bars and text label.
+    TEXT_GAP_PX = 2
+
+    # Multiplier applied to font line_height for text label sizing.
+    TEXT_HEIGHT_FACTOR = 1.2
+
     # Maps user-facing symbology symbols to their Barby class name and require path.
     #
     # @return [Hash{Symbol => Hash}]
@@ -49,17 +55,33 @@ module ChromaWave
               'text_font: is required when include_text: true'
       end
 
-      barcode = build_barcode(symbology, data)
-      encoding = barcode.encoding.is_a?(Array) ? barcode.encoding.join : barcode.encoding
+      encoding = encode(symbology, data)
 
       total_width = encoding.length * module_width
       total_height = if include_text
-                       height + 2 + (text_font.line_height * 1.2).round
+                       height + TEXT_GAP_PX + (text_font.line_height * TEXT_HEIGHT_FACTOR).round
                      else
                        height
                      end
 
       Metrics.new(width: total_width, height: total_height, encoding_length: encoding.length)
+    end
+
+    # Encodes data for the given symbology and returns the flat binary encoding string.
+    #
+    # Each character in the returned string is +'1'+ (dark bar) or +'0'+ (space).
+    # This is the single source of truth for barcode encoding; both {.measure}
+    # and {Drawing::Codes#draw_barcode} delegate here.
+    #
+    # @param symbology [Symbol] symbology key (e.g. +:code128+, +:ean13+)
+    # @param data [String] data to encode
+    # @return [String] binary encoding string of '1' and '0' characters
+    # @raise [ArgumentError] if symbology is unknown or data is invalid for the symbology
+    # @raise [DependencyError] if barby is not installed
+    def self.encode(symbology, data)
+      barcode = build_barcode(symbology, data)
+      encoding = barcode.encoding
+      encoding.is_a?(Array) ? encoding.join : encoding
     end
 
     # Builds a Barby barcode instance for the given symbology and data.
@@ -97,6 +119,6 @@ module ChromaWave
             'Install it with: gem install barby'
     end
 
-    private_class_method :require_barby!
+    private_class_method :build_barcode, :require_barby!
   end
 end

--- a/lib/chroma_wave/barcode.rb
+++ b/lib/chroma_wave/barcode.rb
@@ -119,6 +119,6 @@ module ChromaWave
             'Install it with: gem install barby'
     end
 
-    private_class_method :build_barcode, :require_barby!
+    private_class_method :build_barcode
   end
 end

--- a/lib/chroma_wave/barcode.rb
+++ b/lib/chroma_wave/barcode.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module ChromaWave
+  # Standalone barcode utilities.
+  #
+  # Provides measurement helpers and barcode construction that don't
+  # require a drawing surface, so callers can compute pixel dimensions
+  # for centering or layout before committing to a +draw_barcode+ call.
+  #
+  # @example
+  #   metrics = ChromaWave::Barcode.measure("ABC123", symbology: :code128)
+  #   metrics.width  # => total pixel width of the rendered barcode
+  #   metrics.height # => total pixel height (bars only, unless include_text)
+  module Barcode
+    # Maps user-facing symbology symbols to their Barby class name and require path.
+    #
+    # @return [Hash{Symbol => Hash}]
+    SYMBOLOGIES = {
+      code128: { class_name: 'Barby::Code128', require_path: 'barby/barcode/code_128' },
+      ean13: { class_name: 'Barby::EAN13', require_path: 'barby/barcode/ean_13' },
+      ean8: { class_name: 'Barby::EAN8', require_path: 'barby/barcode/ean_8' },
+      code39: { class_name: 'Barby::Code39', require_path: 'barby/barcode/code_39' }
+    }.freeze
+
+    # Pixel dimensions and encoding length for a barcode.
+    #
+    # @!attribute [r] width
+    #   @return [Integer] total width in pixels
+    # @!attribute [r] height
+    #   @return [Integer] total height in pixels
+    # @!attribute [r] encoding_length
+    #   @return [Integer] number of modules in the binary encoding
+    Metrics = Data.define(:width, :height, :encoding_length)
+
+    # Builds a Barby barcode instance for the given symbology and data.
+    #
+    # @param symbology [Symbol] symbology key (e.g. +:code128+, +:ean13+)
+    # @param data [String] data to encode
+    # @return [Barby::Barcode] the barcode instance
+    # @raise [ArgumentError] if symbology is unknown or data is invalid for the symbology
+    # @raise [DependencyError] if barby is not installed
+    def self.build_barcode(symbology, data)
+      require_barby!
+      spec = SYMBOLOGIES.fetch(symbology) do
+        raise ArgumentError, "unknown symbology: #{symbology.inspect} " \
+                             "(expected #{SYMBOLOGIES.keys.map(&:inspect).join(', ')})"
+      end
+
+      require spec[:require_path]
+      begin
+        Object.const_get(spec[:class_name]).new(data)
+      rescue ArgumentError => e
+        raise ArgumentError, "invalid data for #{symbology}: #{e.message}"
+      end
+    end
+
+    # Lazily requires barby, raising DependencyError if not installed.
+    #
+    # @raise [DependencyError] if barby cannot be loaded
+    def self.require_barby!
+      return if defined?(::Barby)
+
+      require 'barby'
+    rescue LoadError
+      raise DependencyError,
+            'barby is required for barcode support. ' \
+            'Install it with: gem install barby'
+    end
+
+    private_class_method :require_barby!
+  end
+end

--- a/lib/chroma_wave/barcode.rb
+++ b/lib/chroma_wave/barcode.rb
@@ -32,6 +32,36 @@ module ChromaWave
     #   @return [Integer] number of modules in the binary encoding
     Metrics = Data.define(:width, :height, :encoding_length)
 
+    # Computes the pixel dimensions of a barcode without rendering it.
+    #
+    # @param data [String] the data to encode
+    # @param symbology [Symbol] symbology key (e.g. +:code128+, +:ean13+)
+    # @param module_width [Integer] pixel width per narrow bar
+    # @param height [Integer] bar height in pixels
+    # @param include_text [Boolean] whether text will be rendered below bars
+    # @param text_font [Font, nil] font for text (required if include_text)
+    # @return [Metrics] frozen value object with width, height, and encoding length
+    # @raise [ArgumentError] if symbology is unknown, data is invalid, or text_font missing
+    # @raise [DependencyError] if barby is not installed
+    def self.measure(data, symbology:, module_width: 2, height: 60, include_text: false, text_font: nil)
+      if include_text && text_font.nil?
+        raise ArgumentError,
+              'text_font: is required when include_text: true'
+      end
+
+      barcode = build_barcode(symbology, data)
+      encoding = barcode.encoding.is_a?(Array) ? barcode.encoding.join : barcode.encoding
+
+      total_width = encoding.length * module_width
+      total_height = if include_text
+                       height + 2 + (text_font.line_height * 1.2).round
+                     else
+                       height
+                     end
+
+      Metrics.new(width: total_width, height: total_height, encoding_length: encoding.length)
+    end
+
     # Builds a Barby barcode instance for the given symbology and data.
     #
     # @param symbology [Symbol] symbology key (e.g. +:code128+, +:ean13+)

--- a/lib/chroma_wave/drawing/codes.rb
+++ b/lib/chroma_wave/drawing/codes.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+module ChromaWave
+  module Drawing
+    # QR code and barcode rendering mixin for {Surface}.
+    #
+    # Provides +draw_qr+ and +draw_barcode+ methods that compose on
+    # +fill_rect+ (from {Drawing::Primitives}) so they work on any
+    # surface type. The +include_text+ option for barcodes requires
+    # +draw_text+ (Canvas/Layer only).
+    #
+    # Both methods return +self+ for chaining.
+    module Codes
+      # Maps user-facing symbology symbols to Barby class name strings.
+      SYMBOLOGY_MAP = {
+        code128: 'Barby::Code128',
+        ean13: 'Barby::EAN13',
+        ean8: 'Barby::EAN8',
+        code39: 'Barby::Code39'
+      }.freeze
+
+      # Maps symbology symbols to their require paths.
+      SYMBOLOGY_REQUIRES = {
+        code128: 'barby/barcode/code_128',
+        ean13: 'barby/barcode/ean_13',
+        ean8: 'barby/barcode/ean_8',
+        code39: 'barby/barcode/code_39'
+      }.freeze
+
+      # Draws a QR code onto this surface.
+      #
+      # Each dark module is rendered as a filled square via +fill_rect+.
+      # Sizing can be explicit (+module_size+) or auto-fit
+      # (+max_width+ / +max_height+).
+      #
+      # @param data [String] the data to encode
+      # @param x [Integer] top-left x coordinate
+      # @param y [Integer] top-left y coordinate
+      # @param module_size [Integer, nil] pixel size per QR module (overrides max_width/max_height)
+      # @param color [Color] dark module color
+      # @param background [Color, nil] background color (nil = transparent)
+      # @param error_correction [Symbol] +:low+, +:medium+, +:quartile+, or +:high+
+      # @param max_width [Integer, nil] maximum width for auto-fit
+      # @param max_height [Integer, nil] maximum height for auto-fit
+      # @return [self]
+      # @raise [ArgumentError] if no sizing info is provided or error_correction is unknown
+      # @raise [DependencyError] if rqrcode is not installed
+      def draw_qr(data, x:, y:, module_size: nil, color: Color::BLACK, background: nil, # rubocop:disable Metrics/ParameterLists
+                  error_correction: :medium, max_width: nil, max_height: nil)
+        QR.send(:require_rqrcode!)
+        level = QR.resolve_level(error_correction)
+        qr = ::RQRCode::QRCode.new(data, level: level)
+        modules = qr.modules
+        n = modules.length
+
+        msize = resolve_module_size(module_size, n, max_width, max_height)
+        render_qr_background(x, y, n, msize, background) if background
+        render_qr_modules(x, y, modules, msize, color)
+
+        self
+      end
+
+      # Draws a 1D barcode onto this surface.
+      #
+      # Bar runs are rendered via +fill_rect+. When +include_text+ is true,
+      # the data string is centered below the bars via +draw_text+ (Canvas/Layer
+      # only — raises on Framebuffer).
+      #
+      # @param data [String] the data to encode
+      # @param x [Integer] top-left x coordinate
+      # @param y [Integer] top-left y coordinate
+      # @param symbology [Symbol] +:code128+, +:ean13+, +:ean8+, or +:code39+
+      # @param height [Integer] bar height in pixels
+      # @param module_width [Integer] pixel width per narrow bar
+      # @param color [Color] bar color
+      # @param background [Color, nil] background color (nil = transparent)
+      # @param include_text [Boolean] render data text below bars
+      # @param text_font [Font, nil] font for text (required if include_text)
+      # @return [self]
+      # @raise [ArgumentError] if symbology is unknown or include_text on a non-text surface
+      # @raise [DependencyError] if barby is not installed
+      def draw_barcode(data, x:, y:, symbology:, height: 60, module_width: 2, # rubocop:disable Metrics/ParameterLists
+                       color: Color::BLACK, background: nil, include_text: true,
+                       text_font: nil)
+        validate_text_capable!(include_text)
+        barcode = build_barcode(symbology, data)
+        encoding = barcode.encoding.is_a?(Array) ? barcode.encoding.join : barcode.encoding
+
+        total_width = encoding.length * module_width
+        render_barcode_background(x, y, total_width, height, background) if background
+        render_barcode_bars(x, y, encoding, module_width, height, color)
+        render_barcode_text(data, x, y + height + 2, total_width, text_font, color) if include_text
+
+        self
+      end
+
+      private
+
+      # Resolves the effective module_size from explicit or auto-fit parameters.
+      #
+      # @param module_size [Integer, nil] explicit module size
+      # @param n_modules [Integer] number of QR modules per side
+      # @param max_width [Integer, nil] maximum width constraint
+      # @param max_height [Integer, nil] maximum height constraint
+      # @return [Integer] resolved module size (>= 1)
+      # @raise [ArgumentError] if no sizing info or module_size < 1
+      def resolve_module_size(module_size, n_modules, max_width, max_height)
+        if module_size
+          unless module_size.is_a?(Integer) && module_size >= 1
+            raise ArgumentError,
+                  'module_size must be a positive Integer'
+          end
+
+          return module_size
+        end
+
+        unless max_width || max_height
+          raise ArgumentError,
+                'provide module_size: or max_width:/max_height: to size the QR code'
+        end
+
+        candidates = []
+        candidates << (max_width / n_modules) if max_width
+        candidates << (max_height / n_modules) if max_height
+        [candidates.min, 1].max
+      end
+
+      # Fills the QR background as a single rectangle.
+      #
+      # @param x [Integer] top-left x
+      # @param y [Integer] top-left y
+      # @param n_modules [Integer] number of modules per side
+      # @param msize [Integer] module pixel size
+      # @param color [Color] background color
+      def render_qr_background(x, y, n_modules, msize, color)
+        total = n_modules * msize
+        fill_rect(x, y, total, total, color)
+      end
+
+      # Renders dark QR modules as filled rectangles.
+      #
+      # @param x [Integer] top-left x
+      # @param y [Integer] top-left y
+      # @param modules [Array<Array<Boolean>>] 2D module matrix
+      # @param msize [Integer] module pixel size
+      # @param color [Color] dark module color
+      def render_qr_modules(x, y, modules, msize, color)
+        modules.each_with_index do |row, row_idx|
+          row.each_with_index do |dark, col_idx|
+            next unless dark
+
+            fill_rect(x + (col_idx * msize), y + (row_idx * msize), msize, msize, color)
+          end
+        end
+      end
+
+      # Lazily requires barby, raising DependencyError if not installed.
+      #
+      # @raise [DependencyError] if barby cannot be loaded
+      def require_barby!
+        return if defined?(::Barby)
+
+        require 'barby'
+      rescue LoadError
+        raise DependencyError,
+              'barby is required for barcode support. ' \
+              'Install it with: gem install barby'
+      end
+
+      # Validates that this surface supports text rendering.
+      #
+      # @param include_text [Boolean] whether text is requested
+      # @raise [ArgumentError] if text is requested but surface lacks draw_text
+      def validate_text_capable!(include_text)
+        return unless include_text
+        return if respond_to?(:draw_text)
+
+        raise ArgumentError,
+              'include_text: true requires draw_text (available on Canvas and Layer, not Framebuffer)'
+      end
+
+      # Builds a Barby barcode instance for the given symbology and data.
+      #
+      # @param symbology [Symbol] symbology key
+      # @param data [String] data to encode
+      # @return [Barby::Barcode] the barcode instance
+      # @raise [ArgumentError] if symbology is unknown
+      def build_barcode(symbology, data)
+        require_barby!
+        klass_name = SYMBOLOGY_MAP.fetch(symbology) do
+          raise ArgumentError, "unknown symbology: #{symbology.inspect} " \
+                               "(expected #{SYMBOLOGY_MAP.keys.map(&:inspect).join(', ')})"
+        end
+
+        require SYMBOLOGY_REQUIRES.fetch(symbology)
+        Object.const_get(klass_name).new(data)
+      end
+
+      # Fills the barcode background as a single rectangle.
+      #
+      # @param x [Integer] top-left x
+      # @param y [Integer] top-left y
+      # @param total_width [Integer] total barcode width in pixels
+      # @param height [Integer] bar height
+      # @param color [Color] background color
+      def render_barcode_background(x, y, total_width, height, color)
+        fill_rect(x, y, total_width, height, color)
+      end
+
+      # Renders barcode bars using run-length scanning.
+      #
+      # Scans the encoding string for consecutive '1' runs and emits
+      # one +fill_rect+ per run. O(n) over encoding length.
+      #
+      # @param x [Integer] top-left x
+      # @param y [Integer] top-left y
+      # @param encoding [String] binary encoding string ('1'/'0')
+      # @param module_width [Integer] pixel width per module
+      # @param height [Integer] bar height
+      # @param color [Color] bar color
+      def render_barcode_bars(x, y, encoding, module_width, height, color)
+        run_start = nil
+
+        encoding.each_char.with_index do |ch, i|
+          if ch == '1'
+            run_start ||= i
+          elsif run_start
+            run_len = i - run_start
+            fill_rect(x + (run_start * module_width), y, run_len * module_width, height, color)
+            run_start = nil
+          end
+        end
+
+        # Flush trailing run
+        return unless run_start
+
+        run_len = encoding.length - run_start
+        fill_rect(x + (run_start * module_width), y, run_len * module_width, height, color)
+      end
+
+      # Renders the data text centered below the barcode bars.
+      #
+      # @param data [String] the original data string
+      # @param x [Integer] barcode top-left x
+      # @param text_y [Integer] y coordinate for the text baseline
+      # @param total_width [Integer] total barcode width for centering
+      # @param font [Font, nil] text font
+      # @param color [Color] text color
+      def render_barcode_text(data, x, text_y, total_width, font, color)
+        draw_text(data, x: x, y: text_y, font: font, color: color,
+                        align: :center, max_width: total_width)
+      end
+    end
+  end
+end
+
+# Include code rendering into Surface so all surfaces can draw QR/barcodes.
+ChromaWave::Surface.include(ChromaWave::Drawing::Codes)

--- a/lib/chroma_wave/drawing/codes.rb
+++ b/lib/chroma_wave/drawing/codes.rb
@@ -30,6 +30,8 @@ module ChromaWave
       # @note Framebuffer surfaces use palette symbols (+:black+, +:white+, etc.)
       #   instead of +Color+ objects. Pass a palette symbol for +color:+ and
       #   +background:+ when drawing on a Framebuffer.
+      # @note Pixels that fall outside the surface bounds are silently clipped
+      #   by the underlying +set_pixel+ implementation.
       # @return [self]
       # @raise [ArgumentError] if no sizing info is provided or error_correction is unknown
       # @raise [DependencyError] if rqrcode is not installed
@@ -68,22 +70,23 @@ module ChromaWave
       # @note Framebuffer surfaces use palette symbols (+:black+, +:white+, etc.)
       #   instead of +Color+ objects. Pass a palette symbol for +color:+ and
       #   +background:+ when drawing on a Framebuffer.
+      # @note Pixels that fall outside the surface bounds are silently clipped
+      #   by the underlying +set_pixel+ implementation.
       # @return [self]
       # @raise [ArgumentError] if symbology is unknown or include_text on a non-text surface
       # @raise [DependencyError] if barby is not installed
       def draw_barcode(data, x:, y:, symbology:, height: 60, module_width: 2, # rubocop:disable Metrics/ParameterLists
-                       color: Color::BLACK, background: nil, include_text: true,
+                       color: Color::BLACK, background: nil, include_text: false,
                        text_font: nil)
         validate_text_capable!(include_text)
         validate_text_font!(include_text, text_font)
-        barcode = Barcode.build_barcode(symbology, data)
-        encoding = barcode.encoding.is_a?(Array) ? barcode.encoding.join : barcode.encoding
+        encoding = Barcode.encode(symbology, data)
 
         total_width = encoding.length * module_width
         total_height = compute_barcode_height(height, include_text, text_font)
         render_barcode_background(x, y, total_width, total_height, background) if background
         render_barcode_bars(x, y, encoding, module_width, height, color)
-        render_barcode_text(data, x, y + height + 2, total_width, text_font, color) if include_text
+        render_barcode_text(data, x, y + height + Barcode::TEXT_GAP_PX, total_width, text_font, color) if include_text
 
         self
       end
@@ -94,7 +97,7 @@ module ChromaWave
       #
       # @raise [DependencyError] if rqrcode cannot be loaded
       def require_rqrcode!
-        QR.send(:require_rqrcode!)
+        QR.require_rqrcode!
       end
 
       # Resolves the effective module_size from explicit or auto-fit parameters.
@@ -203,7 +206,7 @@ module ChromaWave
       def compute_barcode_height(bar_height, include_text, text_font)
         return bar_height unless include_text
 
-        bar_height + 2 + (text_font.line_height * 1.2).round
+        bar_height + Barcode::TEXT_GAP_PX + (text_font.line_height * Barcode::TEXT_HEIGHT_FACTOR).round
       end
 
       # Fills the barcode background as a single rectangle.

--- a/lib/chroma_wave/drawing/codes.rb
+++ b/lib/chroma_wave/drawing/codes.rb
@@ -21,21 +21,22 @@ module ChromaWave
       # @param x [Integer] top-left x coordinate
       # @param y [Integer] top-left y coordinate
       # @param module_size [Integer, nil] pixel size per QR module (overrides max_width/max_height)
-      # @param color [Color] dark module color
-      # @param background [Color, nil] background color (nil = transparent)
+      # @param color [Color, Symbol] dark module color (auto-detected per surface type)
+      # @param background [Color, Symbol, nil] background color (nil = transparent)
       # @param error_correction [Symbol] +:low+, +:medium+, +:quartile+, or +:high+
       # @param max_width [Integer, nil] maximum width for auto-fit
       # @param max_height [Integer, nil] maximum height for auto-fit
       # @param quiet_zone [Integer] number of empty modules around the QR code (default 4)
-      # @note Framebuffer surfaces use palette symbols (+:black+, +:white+, etc.)
-      #   instead of +Color+ objects. Pass a palette symbol for +color:+ and
-      #   +background:+ when drawing on a Framebuffer.
+      # @note The +color:+ default adapts to the surface type: +Color::BLACK+ for
+      #   Canvas/Layer, +:black+ for Framebuffer. You may still pass an explicit
+      #   value. Framebuffer surfaces require palette symbols (+:black+, +:white+,
+      #   etc.) for both +color:+ and +background:+.
       # @note Pixels that fall outside the surface bounds are silently clipped
       #   by the underlying +set_pixel+ implementation.
       # @return [self]
       # @raise [ArgumentError] if no sizing info is provided or error_correction is unknown
       # @raise [DependencyError] if rqrcode is not installed
-      def draw_qr(data, x:, y:, module_size: nil, color: Color::BLACK, background: nil, # rubocop:disable Metrics/ParameterLists
+      def draw_qr(data, x:, y:, module_size: nil, color: default_foreground, background: nil, # rubocop:disable Metrics/ParameterLists
                   error_correction: :medium, max_width: nil, max_height: nil, quiet_zone: 4)
         validate_quiet_zone!(quiet_zone)
         require_rqrcode!
@@ -63,20 +64,21 @@ module ChromaWave
       # @param symbology [Symbol] +:code128+, +:ean13+, +:ean8+, or +:code39+
       # @param height [Integer] bar height in pixels
       # @param module_width [Integer] pixel width per narrow bar
-      # @param color [Color] bar color
-      # @param background [Color, nil] background color (nil = transparent)
+      # @param color [Color, Symbol] bar color (auto-detected per surface type)
+      # @param background [Color, Symbol, nil] background color (nil = transparent)
       # @param include_text [Boolean] render data text below bars
       # @param text_font [Font, nil] font for text (required if include_text)
-      # @note Framebuffer surfaces use palette symbols (+:black+, +:white+, etc.)
-      #   instead of +Color+ objects. Pass a palette symbol for +color:+ and
-      #   +background:+ when drawing on a Framebuffer.
+      # @note The +color:+ default adapts to the surface type: +Color::BLACK+ for
+      #   Canvas/Layer, +:black+ for Framebuffer. You may still pass an explicit
+      #   value. Framebuffer surfaces require palette symbols (+:black+, +:white+,
+      #   etc.) for both +color:+ and +background:+.
       # @note Pixels that fall outside the surface bounds are silently clipped
       #   by the underlying +set_pixel+ implementation.
       # @return [self]
       # @raise [ArgumentError] if symbology is unknown or include_text on a non-text surface
       # @raise [DependencyError] if barby is not installed
       def draw_barcode(data, x:, y:, symbology:, height: 60, module_width: 2, # rubocop:disable Metrics/ParameterLists
-                       color: Color::BLACK, background: nil, include_text: false,
+                       color: default_foreground, background: nil, include_text: false,
                        text_font: nil)
         validate_text_capable!(include_text)
         validate_text_font!(include_text, text_font)
@@ -92,6 +94,16 @@ module ChromaWave
       end
 
       private
+
+      # Returns a sensible default foreground color for the current surface.
+      #
+      # Framebuffer surfaces use palette symbols; Canvas/Layer use Color objects.
+      # Duck-types on +pixel_format+ to detect palette-based surfaces.
+      #
+      # @return [Symbol, Color] +:black+ for palette surfaces, +Color::BLACK+ otherwise
+      def default_foreground
+        respond_to?(:pixel_format) ? :black : Color::BLACK
+      end
 
       # Lazily requires rqrcode, raising DependencyError if not installed.
       #

--- a/lib/chroma_wave/drawing/codes.rb
+++ b/lib/chroma_wave/drawing/codes.rb
@@ -26,20 +26,22 @@ module ChromaWave
       # @param error_correction [Symbol] +:low+, +:medium+, +:quartile+, or +:high+
       # @param max_width [Integer, nil] maximum width for auto-fit
       # @param max_height [Integer, nil] maximum height for auto-fit
+      # @param quiet_zone [Integer] number of empty modules around the QR code (default 4)
       # @return [self]
       # @raise [ArgumentError] if no sizing info is provided or error_correction is unknown
       # @raise [DependencyError] if rqrcode is not installed
       def draw_qr(data, x:, y:, module_size: nil, color: Color::BLACK, background: nil, # rubocop:disable Metrics/ParameterLists
-                  error_correction: :medium, max_width: nil, max_height: nil)
+                  error_correction: :medium, max_width: nil, max_height: nil, quiet_zone: 4)
+        validate_quiet_zone!(quiet_zone)
         require_rqrcode!
         level = QR.resolve_level(error_correction)
         qr = ::RQRCode::QRCode.new(data, level: level)
         modules = qr.modules
         n = modules.length
 
-        msize = resolve_module_size(module_size, n, max_width, max_height)
-        render_qr_background(x, y, n, msize, background) if background
-        render_qr_modules(x, y, modules, msize, color)
+        msize = resolve_module_size(module_size, n, max_width, max_height, quiet_zone)
+        render_qr_background(x, y, n, msize, quiet_zone, background) if background
+        render_qr_modules(x, y, modules, msize, quiet_zone, color)
 
         self
       end
@@ -94,9 +96,10 @@ module ChromaWave
       # @param n_modules [Integer] number of QR modules per side
       # @param max_width [Integer, nil] maximum width constraint
       # @param max_height [Integer, nil] maximum height constraint
+      # @param quiet_zone [Integer] quiet zone module count per side
       # @return [Integer] resolved module size (>= 1)
       # @raise [ArgumentError] if no sizing info or module_size < 1
-      def resolve_module_size(module_size, n_modules, max_width, max_height)
+      def resolve_module_size(module_size, n_modules, max_width, max_height, quiet_zone)
         if module_size
           unless module_size.is_a?(Integer) && module_size >= 1
             raise ArgumentError,
@@ -111,39 +114,53 @@ module ChromaWave
                 'provide module_size: or max_width:/max_height: to size the QR code'
         end
 
+        total_modules = n_modules + (2 * quiet_zone)
         candidates = []
-        candidates << (max_width / n_modules) if max_width
-        candidates << (max_height / n_modules) if max_height
+        candidates << (max_width / total_modules) if max_width
+        candidates << (max_height / total_modules) if max_height
         [candidates.min, 1].max
       end
 
-      # Fills the QR background as a single rectangle.
+      # Fills the QR background as a single rectangle including the quiet zone.
       #
       # @param x [Integer] top-left x
       # @param y [Integer] top-left y
       # @param n_modules [Integer] number of modules per side
       # @param msize [Integer] module pixel size
+      # @param quiet_zone [Integer] quiet zone module count per side
       # @param color [Color] background color
-      def render_qr_background(x, y, n_modules, msize, color)
-        total = n_modules * msize
+      def render_qr_background(x, y, n_modules, msize, quiet_zone, color)
+        total = (n_modules + (2 * quiet_zone)) * msize
         fill_rect(x, y, total, total, color)
       end
 
-      # Renders dark QR modules as filled rectangles.
+      # Renders dark QR modules as filled rectangles, offset by the quiet zone.
       #
       # @param x [Integer] top-left x
       # @param y [Integer] top-left y
       # @param modules [Array<Array<Boolean>>] 2D module matrix
       # @param msize [Integer] module pixel size
+      # @param quiet_zone [Integer] quiet zone module count per side
       # @param color [Color] dark module color
-      def render_qr_modules(x, y, modules, msize, color)
+      def render_qr_modules(x, y, modules, msize, quiet_zone, color)
+        offset = quiet_zone * msize
         modules.each_with_index do |row, row_idx|
           row.each_with_index do |dark, col_idx|
             next unless dark
 
-            fill_rect(x + (col_idx * msize), y + (row_idx * msize), msize, msize, color)
+            fill_rect(x + offset + (col_idx * msize), y + offset + (row_idx * msize), msize, msize, color)
           end
         end
+      end
+
+      # Validates the quiet zone parameter.
+      #
+      # @param quiet_zone [Integer] quiet zone module count
+      # @raise [ArgumentError] if quiet_zone is not a non-negative Integer
+      def validate_quiet_zone!(quiet_zone)
+        return if quiet_zone.is_a?(Integer) && quiet_zone >= 0
+
+        raise ArgumentError, 'quiet_zone must be a non-negative Integer'
       end
 
       # Validates that this surface supports text rendering.

--- a/lib/chroma_wave/drawing/codes.rb
+++ b/lib/chroma_wave/drawing/codes.rb
@@ -27,6 +27,9 @@ module ChromaWave
       # @param max_width [Integer, nil] maximum width for auto-fit
       # @param max_height [Integer, nil] maximum height for auto-fit
       # @param quiet_zone [Integer] number of empty modules around the QR code (default 4)
+      # @note Framebuffer surfaces use palette symbols (+:black+, +:white+, etc.)
+      #   instead of +Color+ objects. Pass a palette symbol for +color:+ and
+      #   +background:+ when drawing on a Framebuffer.
       # @return [self]
       # @raise [ArgumentError] if no sizing info is provided or error_correction is unknown
       # @raise [DependencyError] if rqrcode is not installed
@@ -62,6 +65,9 @@ module ChromaWave
       # @param background [Color, nil] background color (nil = transparent)
       # @param include_text [Boolean] render data text below bars
       # @param text_font [Font, nil] font for text (required if include_text)
+      # @note Framebuffer surfaces use palette symbols (+:black+, +:white+, etc.)
+      #   instead of +Color+ objects. Pass a palette symbol for +color:+ and
+      #   +background:+ when drawing on a Framebuffer.
       # @return [self]
       # @raise [ArgumentError] if symbology is unknown or include_text on a non-text surface
       # @raise [DependencyError] if barby is not installed

--- a/lib/chroma_wave/drawing/codes.rb
+++ b/lib/chroma_wave/drawing/codes.rb
@@ -11,22 +11,6 @@ module ChromaWave
     #
     # Both methods return +self+ for chaining.
     module Codes
-      # Maps user-facing symbology symbols to Barby class name strings.
-      SYMBOLOGY_MAP = {
-        code128: 'Barby::Code128',
-        ean13: 'Barby::EAN13',
-        ean8: 'Barby::EAN8',
-        code39: 'Barby::Code39'
-      }.freeze
-
-      # Maps symbology symbols to their require paths.
-      SYMBOLOGY_REQUIRES = {
-        code128: 'barby/barcode/code_128',
-        ean13: 'barby/barcode/ean_13',
-        ean8: 'barby/barcode/ean_8',
-        code39: 'barby/barcode/code_39'
-      }.freeze
-
       # Draws a QR code onto this surface.
       #
       # Each dark module is rendered as a filled square via +fill_rect+.
@@ -47,7 +31,7 @@ module ChromaWave
       # @raise [DependencyError] if rqrcode is not installed
       def draw_qr(data, x:, y:, module_size: nil, color: Color::BLACK, background: nil, # rubocop:disable Metrics/ParameterLists
                   error_correction: :medium, max_width: nil, max_height: nil)
-        QR.send(:require_rqrcode!)
+        require_rqrcode!
         level = QR.resolve_level(error_correction)
         qr = ::RQRCode::QRCode.new(data, level: level)
         modules = qr.modules
@@ -83,7 +67,7 @@ module ChromaWave
                        color: Color::BLACK, background: nil, include_text: true,
                        text_font: nil)
         validate_text_capable!(include_text)
-        barcode = build_barcode(symbology, data)
+        barcode = Barcode.build_barcode(symbology, data)
         encoding = barcode.encoding.is_a?(Array) ? barcode.encoding.join : barcode.encoding
 
         total_width = encoding.length * module_width
@@ -95,6 +79,13 @@ module ChromaWave
       end
 
       private
+
+      # Lazily requires rqrcode, raising DependencyError if not installed.
+      #
+      # @raise [DependencyError] if rqrcode cannot be loaded
+      def require_rqrcode!
+        QR.send(:require_rqrcode!)
+      end
 
       # Resolves the effective module_size from explicit or auto-fit parameters.
       #
@@ -154,19 +145,6 @@ module ChromaWave
         end
       end
 
-      # Lazily requires barby, raising DependencyError if not installed.
-      #
-      # @raise [DependencyError] if barby cannot be loaded
-      def require_barby!
-        return if defined?(::Barby)
-
-        require 'barby'
-      rescue LoadError
-        raise DependencyError,
-              'barby is required for barcode support. ' \
-              'Install it with: gem install barby'
-      end
-
       # Validates that this surface supports text rendering.
       #
       # @param include_text [Boolean] whether text is requested
@@ -177,23 +155,6 @@ module ChromaWave
 
         raise ArgumentError,
               'include_text: true requires draw_text (available on Canvas and Layer, not Framebuffer)'
-      end
-
-      # Builds a Barby barcode instance for the given symbology and data.
-      #
-      # @param symbology [Symbol] symbology key
-      # @param data [String] data to encode
-      # @return [Barby::Barcode] the barcode instance
-      # @raise [ArgumentError] if symbology is unknown
-      def build_barcode(symbology, data)
-        require_barby!
-        klass_name = SYMBOLOGY_MAP.fetch(symbology) do
-          raise ArgumentError, "unknown symbology: #{symbology.inspect} " \
-                               "(expected #{SYMBOLOGY_MAP.keys.map(&:inspect).join(', ')})"
-        end
-
-        require SYMBOLOGY_REQUIRES.fetch(symbology)
-        Object.const_get(klass_name).new(data)
       end
 
       # Fills the barcode background as a single rectangle.

--- a/lib/chroma_wave/drawing/codes.rb
+++ b/lib/chroma_wave/drawing/codes.rb
@@ -67,6 +67,7 @@ module ChromaWave
                        color: Color::BLACK, background: nil, include_text: true,
                        text_font: nil)
         validate_text_capable!(include_text)
+        validate_text_font!(include_text, text_font)
         barcode = Barcode.build_barcode(symbology, data)
         encoding = barcode.encoding.is_a?(Array) ? barcode.encoding.join : barcode.encoding
 
@@ -155,6 +156,18 @@ module ChromaWave
 
         raise ArgumentError,
               'include_text: true requires draw_text (available on Canvas and Layer, not Framebuffer)'
+      end
+
+      # Validates that text_font is provided when include_text is true.
+      #
+      # @param include_text [Boolean] whether text is requested
+      # @param text_font [Font, nil] the font for text rendering
+      # @raise [ArgumentError] if include_text is true but text_font is nil
+      def validate_text_font!(include_text, text_font)
+        return unless include_text
+        return unless text_font.nil?
+
+        raise ArgumentError, 'text_font: is required when include_text: true'
       end
 
       # Fills the barcode background as a single rectangle.

--- a/lib/chroma_wave/drawing/codes.rb
+++ b/lib/chroma_wave/drawing/codes.rb
@@ -74,7 +74,8 @@ module ChromaWave
         encoding = barcode.encoding.is_a?(Array) ? barcode.encoding.join : barcode.encoding
 
         total_width = encoding.length * module_width
-        render_barcode_background(x, y, total_width, height, background) if background
+        total_height = compute_barcode_height(height, include_text, text_font)
+        render_barcode_background(x, y, total_width, total_height, background) if background
         render_barcode_bars(x, y, encoding, module_width, height, color)
         render_barcode_text(data, x, y + height + 2, total_width, text_font, color) if include_text
 
@@ -187,12 +188,24 @@ module ChromaWave
         raise ArgumentError, 'text_font: is required when include_text: true'
       end
 
+      # Computes the total barcode height including optional text area.
+      #
+      # @param bar_height [Integer] bar height in pixels
+      # @param include_text [Boolean] whether text is rendered below bars
+      # @param text_font [Font, nil] the font for text rendering
+      # @return [Integer] total height in pixels
+      def compute_barcode_height(bar_height, include_text, text_font)
+        return bar_height unless include_text
+
+        bar_height + 2 + (text_font.line_height * 1.2).round
+      end
+
       # Fills the barcode background as a single rectangle.
       #
       # @param x [Integer] top-left x
       # @param y [Integer] top-left y
       # @param total_width [Integer] total barcode width in pixels
-      # @param height [Integer] bar height
+      # @param height [Integer] total height including text area
       # @param color [Color] background color
       def render_barcode_background(x, y, total_width, height, color)
         fill_rect(x, y, total_width, height, color)

--- a/lib/chroma_wave/qr.rb
+++ b/lib/chroma_wave/qr.rb
@@ -35,15 +35,16 @@ module ChromaWave
     # @param data [String] the data to encode
     # @param module_size [Integer] pixel size of each QR module
     # @param error_correction [Symbol] one of +:low+, +:medium+, +:quartile+, +:high+
+    # @param quiet_zone [Integer] number of empty modules around the QR code (default 4)
     # @return [Metrics] frozen value object with width, height, and module count
     # @raise [ArgumentError] if +error_correction+ is unknown
     # @raise [DependencyError] if rqrcode is not installed
-    def self.measure(data, module_size:, error_correction: :medium)
+    def self.measure(data, module_size:, error_correction: :medium, quiet_zone: 4)
       require_rqrcode!
       level = resolve_level(error_correction)
       qr = ::RQRCode::QRCode.new(data, level: level)
       n = qr.modules.length
-      px = n * module_size
+      px = (n + (2 * quiet_zone)) * module_size
       Metrics.new(width: px, height: px, modules: n)
     end
 

--- a/lib/chroma_wave/qr.rb
+++ b/lib/chroma_wave/qr.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module ChromaWave
+  # Standalone QR code utilities.
+  #
+  # Provides measurement helpers that don't require a drawing surface,
+  # so callers can compute pixel dimensions for centering or layout
+  # before committing to a +draw_qr+ call.
+  #
+  # @example
+  #   metrics = ChromaWave::QR.measure("https://example.com", module_size: 4)
+  #   metrics.width  # => pixel width of the rendered QR
+  #   metrics.height # => pixel height (always equal to width)
+  module QR
+    # Maps user-facing error correction symbols to rqrcode's internal symbols.
+    LEVEL_MAP = {
+      low: :l,
+      medium: :m,
+      quartile: :q,
+      high: :h
+    }.freeze
+
+    # Pixel dimensions and module count for a QR code.
+    #
+    # @!attribute [r] width
+    #   @return [Integer] total width in pixels
+    # @!attribute [r] height
+    #   @return [Integer] total height in pixels
+    # @!attribute [r] modules
+    #   @return [Integer] number of modules along one side
+    Metrics = Data.define(:width, :height, :modules)
+
+    # Computes the pixel dimensions of a QR code without rendering it.
+    #
+    # @param data [String] the data to encode
+    # @param module_size [Integer] pixel size of each QR module
+    # @param error_correction [Symbol] one of +:low+, +:medium+, +:quartile+, +:high+
+    # @return [Metrics] frozen value object with width, height, and module count
+    # @raise [ArgumentError] if +error_correction+ is unknown
+    # @raise [DependencyError] if rqrcode is not installed
+    def self.measure(data, module_size:, error_correction: :medium)
+      require_rqrcode!
+      level = resolve_level(error_correction)
+      qr = ::RQRCode::QRCode.new(data, level: level)
+      n = qr.modules.length
+      px = n * module_size
+      Metrics.new(width: px, height: px, modules: n)
+    end
+
+    # Resolves a user-facing error correction symbol to rqrcode's internal symbol.
+    #
+    # @param level [Symbol] one of +:low+, +:medium+, +:quartile+, +:high+
+    # @return [Symbol] rqrcode level symbol
+    # @raise [ArgumentError] if +level+ is unknown
+    def self.resolve_level(level)
+      LEVEL_MAP.fetch(level) do
+        raise ArgumentError, "unknown error_correction: #{level.inspect} " \
+                             "(expected #{LEVEL_MAP.keys.map(&:inspect).join(', ')})"
+      end
+    end
+
+    # Lazily requires rqrcode, raising DependencyError if not installed.
+    #
+    # @raise [DependencyError] if rqrcode cannot be loaded
+    def self.require_rqrcode!
+      return if defined?(::RQRCode)
+
+      require 'rqrcode'
+    rescue LoadError
+      raise DependencyError,
+            'rqrcode is required for QR code support. ' \
+            'Install it with: gem install rqrcode'
+    end
+
+    private_class_method :require_rqrcode!
+  end
+end

--- a/lib/chroma_wave/qr.rb
+++ b/lib/chroma_wave/qr.rb
@@ -73,6 +73,6 @@ module ChromaWave
             'Install it with: gem install rqrcode'
     end
 
-    private_class_method :require_rqrcode!
+    # NOTE: intentionally public so Drawing::Codes can call it directly.
   end
 end

--- a/lib/chroma_wave/surface.rb
+++ b/lib/chroma_wave/surface.rb
@@ -81,3 +81,4 @@ module ChromaWave
 end
 
 require_relative 'drawing/primitives'
+require_relative 'drawing/codes'

--- a/planning/features/006-qr-and-barcodes.md
+++ b/planning/features/006-qr-and-barcodes.md
@@ -42,7 +42,7 @@ canvas.draw_barcode("ABC-123",
   height: 60,                # bar height in pixels
   module_width: 2,           # narrowest bar width (default: 2)
   color: Color::BLACK,
-  include_text: true,        # render human-readable text below (default: true)
+  include_text: true,        # render human-readable text below (default: false)
   text_font: Font.default(size: 12)
 )
 ```
@@ -78,9 +78,9 @@ unavailable at runtime and `include_text: true` is passed, it should raise
 ### Gem Dependencies
 
 ```ruby
-# In gemspec — optional runtime dependencies
-spec.add_dependency "rqrcode", "~> 2.0"  # QR generation
-spec.add_dependency "barby", "~> 0.6"    # 1D barcode generation
+# In Gemfile — optional development/runtime dependencies (lazy-loaded)
+gem "rqrcode", "~> 3.0", require: false  # QR generation
+gem "barby",   "~> 0.7", require: false  # 1D barcode generation
 ```
 
 Both gems are **lazy-loaded** — `require 'rqrcode'` / `require 'barby'` happens on first use.

--- a/spec/chroma_wave/barcode_spec.rb
+++ b/spec/chroma_wave/barcode_spec.rb
@@ -73,19 +73,20 @@ RSpec.describe ChromaWave::Barcode do
     end
   end
 
-  describe '.build_barcode' do
-    it 'returns a Barby barcode instance' do
-      barcode = described_class.build_barcode(:code128, 'ABC123')
-      expect(barcode).to be_a(Barby::Code128)
+  describe '.encode' do
+    it 'returns a binary encoding string' do
+      encoding = described_class.encode(:code128, 'ABC123')
+      expect(encoding).to be_a(String)
+      expect(encoding).to match(/\A[01]+\z/)
     end
 
     it 'raises ArgumentError for unknown symbology' do
-      expect { described_class.build_barcode(:bad, 'test') }
+      expect { described_class.encode(:bad, 'test') }
         .to raise_error(ArgumentError, /unknown symbology: :bad/)
     end
 
     it 'wraps Barby errors with user-friendly message' do
-      expect { described_class.build_barcode(:ean13, 'abc') }
+      expect { described_class.encode(:ean13, 'abc') }
         .to raise_error(ArgumentError, /invalid data for ean13/)
     end
   end
@@ -97,7 +98,7 @@ RSpec.describe ChromaWave::Barcode do
     end
 
     it 'raises DependencyError when barby is not installed' do
-      expect { described_class.build_barcode(:code128, 'test') }
+      expect { described_class.encode(:code128, 'test') }
         .to raise_error(ChromaWave::DependencyError, /barby is required/)
     end
   end

--- a/spec/chroma_wave/barcode_spec.rb
+++ b/spec/chroma_wave/barcode_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+RSpec.describe ChromaWave::Barcode do
+  describe '::SYMBOLOGIES' do
+    it 'contains all supported symbology keys' do
+      expect(described_class::SYMBOLOGIES.keys).to contain_exactly(:code128, :ean13, :ean8, :code39)
+    end
+
+    it 'is frozen' do
+      expect(described_class::SYMBOLOGIES).to be_frozen
+    end
+
+    it 'has class_name and require_path for each symbology' do
+      described_class::SYMBOLOGIES.each_value do |spec|
+        expect(spec).to have_key(:class_name)
+        expect(spec).to have_key(:require_path)
+      end
+    end
+  end
+
+  describe '::Metrics' do
+    subject(:metrics) { described_class::Metrics.new(width: 200, height: 60, encoding_length: 100) }
+
+    it 'is a frozen Data value object' do
+      expect(metrics).to be_frozen
+    end
+
+    it 'exposes width, height, and encoding_length' do
+      expect(metrics.width).to eq(200)
+      expect(metrics.height).to eq(60)
+      expect(metrics.encoding_length).to eq(100)
+    end
+
+    it 'supports structural equality' do
+      other = described_class::Metrics.new(width: 200, height: 60, encoding_length: 100)
+      expect(metrics).to eq(other)
+    end
+  end
+
+  describe '.measure' do
+    it 'returns a Metrics with correct dimensions' do
+      metrics = described_class.measure('ABC123', symbology: :code128)
+      expect(metrics.width).to eq(metrics.encoding_length * 2)
+      expect(metrics.height).to eq(60)
+    end
+
+    it 'uses custom module_width' do
+      metrics = described_class.measure('ABC123', symbology: :code128, module_width: 3)
+      expect(metrics.width).to eq(metrics.encoding_length * 3)
+    end
+
+    it 'uses custom height' do
+      metrics = described_class.measure('ABC123', symbology: :code128, height: 80)
+      expect(metrics.height).to eq(80)
+    end
+
+    it 'includes text height when include_text is true' do
+      font = ChromaWave::Font.default(size: 12)
+      without_text = described_class.measure('ABC123', symbology: :code128, include_text: false)
+      with_text = described_class.measure('ABC123', symbology: :code128,
+                                                    include_text: true, text_font: font)
+      expect(with_text.height).to be > without_text.height
+    end
+
+    it 'raises ArgumentError when include_text is true but text_font is nil' do
+      expect { described_class.measure('ABC123', symbology: :code128, include_text: true) }
+        .to raise_error(ArgumentError, /text_font:.*required.*include_text/)
+    end
+
+    it 'raises ArgumentError for unknown symbology' do
+      expect { described_class.measure('test', symbology: :bad) }
+        .to raise_error(ArgumentError, /unknown symbology: :bad/)
+    end
+  end
+
+  describe '.build_barcode' do
+    it 'returns a Barby barcode instance' do
+      barcode = described_class.build_barcode(:code128, 'ABC123')
+      expect(barcode).to be_a(Barby::Code128)
+    end
+
+    it 'raises ArgumentError for unknown symbology' do
+      expect { described_class.build_barcode(:bad, 'test') }
+        .to raise_error(ArgumentError, /unknown symbology: :bad/)
+    end
+
+    it 'wraps Barby errors with user-friendly message' do
+      expect { described_class.build_barcode(:ean13, 'abc') }
+        .to raise_error(ArgumentError, /invalid data for ean13/)
+    end
+  end
+
+  describe 'dependency guard' do
+    before do
+      hide_const('Barby') if defined?(Barby)
+      allow(described_class).to receive(:require).with('barby').and_raise(LoadError)
+    end
+
+    it 'raises DependencyError when barby is not installed' do
+      expect { described_class.build_barcode(:code128, 'test') }
+        .to raise_error(ChromaWave::DependencyError, /barby is required/)
+    end
+  end
+end

--- a/spec/chroma_wave/drawing/codes_spec.rb
+++ b/spec/chroma_wave/drawing/codes_spec.rb
@@ -186,8 +186,13 @@ RSpec.describe ChromaWave::Drawing::Codes do
 
     context 'with invalid arguments' do
       it 'raises ArgumentError for unknown symbology' do
-        expect { canvas.draw_barcode('test', x: 0, y: 0, symbology: :bad) }
+        expect { canvas.draw_barcode('test', x: 0, y: 0, symbology: :bad, include_text: false) }
           .to raise_error(ArgumentError, /unknown symbology: :bad/)
+      end
+
+      it 'raises ArgumentError when include_text is true but text_font is nil' do
+        expect { canvas.draw_barcode('ABC', x: 0, y: 0, symbology: :code128) }
+          .to raise_error(ArgumentError, /text_font:.*required.*include_text/)
       end
     end
 

--- a/spec/chroma_wave/drawing/codes_spec.rb
+++ b/spec/chroma_wave/drawing/codes_spec.rb
@@ -151,6 +151,22 @@ RSpec.describe ChromaWave::Drawing::Codes do
       end
     end
 
+    context 'with matching measure and render dimensions' do
+      let(:bg) { ChromaWave::Color.new(r: 200, g: 200, b: 200) }
+      let(:metrics) { ChromaWave::QR.measure('hello', module_size: 4) }
+      let(:big) do
+        ChromaWave::Canvas.new(width: 500, height: 500, background: white).tap do |c|
+          c.draw_qr('hello', x: 0, y: 0, module_size: 4, background: bg)
+        end
+      end
+
+      it 'renders pixels within the measured bounding box' do
+        w, h = non_white_extent(big)
+        expect(w).to eq(metrics.width)
+        expect(h).to eq(metrics.height)
+      end
+    end
+
     context 'without required dependency' do
       before do
         hide_const('RQRCode') if defined?(RQRCode)
@@ -239,7 +255,7 @@ RSpec.describe ChromaWave::Drawing::Codes do
       end
 
       it 'raises ArgumentError when include_text is true but text_font is nil' do
-        expect { canvas.draw_barcode('ABC', x: 0, y: 0, symbology: :code128) }
+        expect { canvas.draw_barcode('ABC', x: 0, y: 0, symbology: :code128, include_text: true) }
           .to raise_error(ArgumentError, /text_font:.*required.*include_text/)
       end
     end
@@ -264,6 +280,23 @@ RSpec.describe ChromaWave::Drawing::Codes do
       it 'raises ArgumentError with user-friendly message for invalid EAN data' do
         expect { canvas.draw_barcode('abc', x: 0, y: 0, symbology: :ean13, include_text: false) }
           .to raise_error(ArgumentError, /invalid data for ean13/)
+      end
+    end
+
+    context 'with matching measure and render dimensions' do
+      let(:bg) { ChromaWave::Color.new(r: 200, g: 200, b: 200) }
+      let(:metrics) { ChromaWave::Barcode.measure('ABC123', symbology: :code128) }
+      let(:big) do
+        ChromaWave::Canvas.new(width: 500, height: 500, background: white).tap do |c|
+          c.draw_barcode('ABC123', x: 0, y: 0, symbology: :code128,
+                                   include_text: false, background: bg)
+        end
+      end
+
+      it 'renders pixels within the measured bounding box' do
+        w, h = non_white_extent(big)
+        expect(w).to eq(metrics.width)
+        expect(h).to eq(metrics.height)
       end
     end
 

--- a/spec/chroma_wave/drawing/codes_spec.rb
+++ b/spec/chroma_wave/drawing/codes_spec.rb
@@ -167,6 +167,16 @@ RSpec.describe ChromaWave::Drawing::Codes do
       end
     end
 
+    context 'with Framebuffer surface' do
+      let(:fb) { ChromaWave::Framebuffer.new(100, 100, :mono) }
+
+      it 'defaults color to :black without explicit color argument' do
+        expect do
+          fb.draw_qr('hello', x: 0, y: 0, module_size: 2)
+        end.not_to raise_error
+      end
+    end
+
     context 'without required dependency' do
       before do
         hide_const('RQRCode') if defined?(RQRCode)
@@ -272,6 +282,12 @@ RSpec.describe ChromaWave::Drawing::Codes do
         expect do
           fb.draw_barcode('ABC', x: 0, y: 0, symbology: :code128,
                                  include_text: false, color: :black)
+        end.not_to raise_error
+      end
+
+      it 'defaults color to :black without explicit color argument' do
+        expect do
+          fb.draw_barcode('ABC', x: 0, y: 0, symbology: :code128, include_text: false)
         end.not_to raise_error
       end
     end

--- a/spec/chroma_wave/drawing/codes_spec.rb
+++ b/spec/chroma_wave/drawing/codes_spec.rb
@@ -92,6 +92,33 @@ RSpec.describe ChromaWave::Drawing::Codes do
       end
     end
 
+    context 'with quiet_zone' do
+      it 'renders with default quiet zone (4)' do
+        canvas.draw_qr('hello', x: 0, y: 0, module_size: 2)
+        expect(count_non_white(canvas)).to be_positive
+      end
+
+      it 'renders with quiet_zone: 0' do
+        canvas.draw_qr('hello', x: 0, y: 0, module_size: 2, quiet_zone: 0)
+        expect(count_non_white(canvas)).to be_positive
+      end
+
+      it 'accounts for quiet zone in auto-fit sizing' do
+        # With quiet_zone: 0, auto-fit should produce a larger module size
+        # since there are fewer total modules to fit in the same space
+        canvas_no_qz = ChromaWave::Canvas.new(width: 300, height: 300, background: white)
+        canvas_no_qz.draw_qr('hello', x: 0, y: 0, max_width: 100, quiet_zone: 0)
+        dark_no_qz = count_non_white(canvas_no_qz)
+
+        canvas_with_qz = ChromaWave::Canvas.new(width: 300, height: 300, background: white)
+        canvas_with_qz.draw_qr('hello', x: 0, y: 0, max_width: 100, quiet_zone: 4)
+        dark_with_qz = count_non_white(canvas_with_qz)
+
+        # Larger modules with no quiet zone -> more dark pixels per module
+        expect(dark_no_qz).to be > dark_with_qz
+      end
+    end
+
     context 'with invalid arguments' do
       it 'raises ArgumentError when no sizing info is provided' do
         expect { canvas.draw_qr('hello', x: 0, y: 0) }
@@ -111,6 +138,16 @@ RSpec.describe ChromaWave::Drawing::Codes do
       it 'raises ArgumentError for unknown error_correction' do
         expect { canvas.draw_qr('hello', x: 0, y: 0, module_size: 4, error_correction: :bad) }
           .to raise_error(ArgumentError, /unknown error_correction/)
+      end
+
+      it 'raises ArgumentError for negative quiet_zone' do
+        expect { canvas.draw_qr('hello', x: 0, y: 0, module_size: 4, quiet_zone: -1) }
+          .to raise_error(ArgumentError, /quiet_zone must be a non-negative Integer/)
+      end
+
+      it 'raises ArgumentError for non-integer quiet_zone' do
+        expect { canvas.draw_qr('hello', x: 0, y: 0, module_size: 4, quiet_zone: 2.5) }
+          .to raise_error(ArgumentError, /quiet_zone must be a non-negative Integer/)
       end
     end
 

--- a/spec/chroma_wave/drawing/codes_spec.rb
+++ b/spec/chroma_wave/drawing/codes_spec.rb
@@ -219,6 +219,17 @@ RSpec.describe ChromaWave::Drawing::Codes do
         end
         expect(has_bg).to be(true)
       end
+
+      it 'extends background below bars to cover text area' do
+        bg = ChromaWave::Color.new(r: 200, g: 200, b: 200)
+        canvas.draw_barcode('ABC', x: 10, y: 10, symbology: :code128,
+                                   include_text: true, text_font: font,
+                                   background: bg, height: 60)
+        # Background should extend into the text region below the bars
+        text_area_y = 10 + 60 + 2
+        has_bg = (0...canvas.width).any? { |px| canvas.get_pixel(px, text_area_y) == bg }
+        expect(has_bg).to be(true)
+      end
     end
 
     context 'with invalid arguments' do

--- a/spec/chroma_wave/drawing/codes_spec.rb
+++ b/spec/chroma_wave/drawing/codes_spec.rb
@@ -207,10 +207,17 @@ RSpec.describe ChromaWave::Drawing::Codes do
       end
     end
 
+    context 'with invalid barcode data' do
+      it 'raises ArgumentError with user-friendly message for invalid EAN data' do
+        expect { canvas.draw_barcode('abc', x: 0, y: 0, symbology: :ean13, include_text: false) }
+          .to raise_error(ArgumentError, /invalid data for ean13/)
+      end
+    end
+
     context 'without required dependency' do
       before do
         hide_const('Barby') if defined?(Barby)
-        allow_any_instance_of(described_class).to receive(:require).with('barby').and_raise(LoadError) # rubocop:disable RSpec/AnyInstance
+        allow(ChromaWave::Barcode).to receive(:require).with('barby').and_raise(LoadError)
       end
 
       it 'raises DependencyError when barby is not installed' do

--- a/spec/chroma_wave/drawing/codes_spec.rb
+++ b/spec/chroma_wave/drawing/codes_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+RSpec.describe ChromaWave::Drawing::Codes do
+  let(:white) { ChromaWave::Color::WHITE }
+  let(:black) { ChromaWave::Color::BLACK }
+  let(:red)   { ChromaWave::Color::RED }
+  let(:canvas) { ChromaWave::Canvas.new(width: 300, height: 300, background: white) }
+
+  describe 'module inclusion' do
+    it 'is included in Canvas' do
+      expect(canvas).to respond_to(:draw_qr)
+      expect(canvas).to respond_to(:draw_barcode)
+    end
+
+    it 'is included in Layer' do
+      layer = canvas.layer(x: 0, y: 0, width: 100, height: 100)
+      expect(layer).to respond_to(:draw_qr)
+      expect(layer).to respond_to(:draw_barcode)
+    end
+
+    it 'is included in Framebuffer' do
+      fb = ChromaWave::Framebuffer.new(100, 100, :mono)
+      expect(fb).to respond_to(:draw_qr)
+      expect(fb).to respond_to(:draw_barcode)
+    end
+  end
+
+  describe '#draw_qr' do
+    it 'renders dark pixels onto the canvas' do
+      canvas.draw_qr('hello', x: 0, y: 0, module_size: 4)
+      expect(count_non_white(canvas)).to be_positive
+    end
+
+    it 'returns self for chaining' do
+      result = canvas.draw_qr('hello', x: 0, y: 0, module_size: 4)
+      expect(result).to be(canvas)
+    end
+
+    it 'renders with a custom color' do
+      canvas.draw_qr('hello', x: 0, y: 0, module_size: 4, color: red)
+      has_red = false
+      canvas.width.times do |x|
+        canvas.height.times do |y|
+          has_red = true if canvas.get_pixel(x, y) == red
+        end
+      end
+      expect(has_red).to be(true)
+    end
+
+    it 'renders a background when specified' do
+      bg = ChromaWave::Color.new(r: 200, g: 200, b: 200)
+      canvas.draw_qr('hello', x: 0, y: 0, module_size: 4, background: bg)
+      # Some pixels should be the background color (light modules)
+      has_bg = false
+      canvas.width.times do |x|
+        canvas.height.times do |y|
+          has_bg = true if canvas.get_pixel(x, y) == bg
+        end
+      end
+      expect(has_bg).to be(true)
+    end
+
+    context 'with auto-fit sizing' do
+      it 'auto-fits with max_width' do
+        canvas.draw_qr('hello', x: 0, y: 0, max_width: 100)
+        expect(count_non_white(canvas)).to be_positive
+      end
+
+      it 'auto-fits with max_height' do
+        canvas.draw_qr('hello', x: 0, y: 0, max_height: 100)
+        expect(count_non_white(canvas)).to be_positive
+      end
+
+      it 'auto-fits with both max_width and max_height' do
+        canvas.draw_qr('hello', x: 0, y: 0, max_width: 100, max_height: 80)
+        expect(count_non_white(canvas)).to be_positive
+      end
+
+      it 'clamps module_size to 1 when constraints are very small' do
+        # Even with tiny max, it should still render something
+        canvas.draw_qr('hello', x: 0, y: 0, max_width: 1)
+        expect(count_non_white(canvas)).to be_positive
+      end
+    end
+
+    context 'with error correction levels' do
+      %i[low medium quartile high].each do |level|
+        it "renders with #{level} error correction" do
+          canvas.draw_qr('hello', x: 0, y: 0, module_size: 2, error_correction: level)
+          expect(count_non_white(canvas)).to be_positive
+        end
+      end
+    end
+
+    context 'with invalid arguments' do
+      it 'raises ArgumentError when no sizing info is provided' do
+        expect { canvas.draw_qr('hello', x: 0, y: 0) }
+          .to raise_error(ArgumentError, /module_size.*max_width.*max_height/)
+      end
+
+      it 'raises ArgumentError for module_size < 1' do
+        expect { canvas.draw_qr('hello', x: 0, y: 0, module_size: 0) }
+          .to raise_error(ArgumentError, /module_size must be a positive Integer/)
+      end
+
+      it 'raises ArgumentError for non-integer module_size' do
+        expect { canvas.draw_qr('hello', x: 0, y: 0, module_size: 2.5) }
+          .to raise_error(ArgumentError, /module_size must be a positive Integer/)
+      end
+
+      it 'raises ArgumentError for unknown error_correction' do
+        expect { canvas.draw_qr('hello', x: 0, y: 0, module_size: 4, error_correction: :bad) }
+          .to raise_error(ArgumentError, /unknown error_correction/)
+      end
+    end
+
+    context 'without required dependency' do
+      before do
+        hide_const('RQRCode') if defined?(RQRCode)
+        allow(ChromaWave::QR).to receive(:require).with('rqrcode').and_raise(LoadError)
+      end
+
+      it 'raises DependencyError when rqrcode is not installed' do
+        expect { canvas.draw_qr('hello', x: 0, y: 0, module_size: 4) }
+          .to raise_error(ChromaWave::DependencyError, /rqrcode is required/)
+      end
+    end
+  end
+
+  describe '#draw_barcode' do
+    let(:font) { ChromaWave::Font.default(size: 12) }
+
+    it 'renders bars onto the canvas' do
+      canvas.draw_barcode('ABC123', x: 10, y: 10, symbology: :code128, text_font: font)
+      expect(count_non_white(canvas)).to be_positive
+    end
+
+    it 'returns self for chaining' do
+      result = canvas.draw_barcode('ABC123', x: 10, y: 10, symbology: :code128, text_font: font)
+      expect(result).to be(canvas)
+    end
+
+    context 'with supported symbologies' do
+      it 'renders Code 128' do
+        canvas.draw_barcode('Hello', x: 0, y: 0, symbology: :code128, text_font: font)
+        expect(count_non_white(canvas)).to be_positive
+      end
+
+      it 'renders EAN-13' do
+        canvas.draw_barcode('123456789012', x: 0, y: 0, symbology: :ean13, text_font: font)
+        expect(count_non_white(canvas)).to be_positive
+      end
+
+      it 'renders EAN-8' do
+        canvas.draw_barcode('1234567', x: 0, y: 0, symbology: :ean8, text_font: font)
+        expect(count_non_white(canvas)).to be_positive
+      end
+
+      it 'renders Code 39' do
+        canvas.draw_barcode('HELLO', x: 0, y: 0, symbology: :code39, text_font: font)
+        expect(count_non_white(canvas)).to be_positive
+      end
+    end
+
+    context 'with include_text: false' do
+      it 'renders without text' do
+        canvas.draw_barcode('ABC123', x: 10, y: 10, symbology: :code128, include_text: false)
+        expect(count_non_white(canvas)).to be_positive
+      end
+    end
+
+    context 'with background' do
+      it 'renders a background behind bars' do
+        bg = ChromaWave::Color.new(r: 200, g: 200, b: 200)
+        canvas.draw_barcode('ABC123', x: 10, y: 10, symbology: :code128,
+                                      include_text: false, background: bg)
+        has_bg = false
+        canvas.width.times do |x|
+          canvas.height.times do |y|
+            has_bg = true if canvas.get_pixel(x, y) == bg
+          end
+        end
+        expect(has_bg).to be(true)
+      end
+    end
+
+    context 'with invalid arguments' do
+      it 'raises ArgumentError for unknown symbology' do
+        expect { canvas.draw_barcode('test', x: 0, y: 0, symbology: :bad) }
+          .to raise_error(ArgumentError, /unknown symbology: :bad/)
+      end
+    end
+
+    context 'with Framebuffer surface' do
+      let(:fb) { ChromaWave::Framebuffer.new(200, 100, :mono) }
+
+      it 'raises ArgumentError for include_text: true on Framebuffer' do
+        expect { fb.draw_barcode('ABC', x: 0, y: 0, symbology: :code128, include_text: true) }
+          .to raise_error(ArgumentError, /include_text.*draw_text/)
+      end
+
+      it 'works with include_text: false on Framebuffer' do
+        expect do
+          fb.draw_barcode('ABC', x: 0, y: 0, symbology: :code128,
+                                 include_text: false, color: :black)
+        end.not_to raise_error
+      end
+    end
+
+    context 'without required dependency' do
+      before do
+        hide_const('Barby') if defined?(Barby)
+        allow_any_instance_of(described_class).to receive(:require).with('barby').and_raise(LoadError) # rubocop:disable RSpec/AnyInstance
+      end
+
+      it 'raises DependencyError when barby is not installed' do
+        expect { canvas.draw_barcode('test', x: 0, y: 0, symbology: :code128, include_text: false) }
+          .to raise_error(ChromaWave::DependencyError, /barby is required/)
+      end
+    end
+  end
+end

--- a/spec/chroma_wave/qr_spec.rb
+++ b/spec/chroma_wave/qr_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe ChromaWave::QR do
+  describe '::LEVEL_MAP' do
+    it 'maps all four correction levels' do
+      expect(described_class::LEVEL_MAP).to eq(
+        low: :l, medium: :m, quartile: :q, high: :h
+      )
+    end
+
+    it 'is frozen' do
+      expect(described_class::LEVEL_MAP).to be_frozen
+    end
+  end
+
+  describe '::Metrics' do
+    subject(:metrics) { described_class::Metrics.new(width: 84, height: 84, modules: 21) }
+
+    it 'is a frozen Data value object' do
+      expect(metrics).to be_frozen
+    end
+
+    it 'exposes width, height, and modules' do
+      expect(metrics.width).to eq(84)
+      expect(metrics.height).to eq(84)
+      expect(metrics.modules).to eq(21)
+    end
+
+    it 'supports structural equality' do
+      other = described_class::Metrics.new(width: 84, height: 84, modules: 21)
+      expect(metrics).to eq(other)
+    end
+  end
+
+  describe '.measure' do
+    it 'returns a Metrics with correct pixel dimensions' do
+      metrics = described_class.measure('hello', module_size: 4)
+      qr = RQRCode::QRCode.new('hello', level: :m)
+      n = qr.modules.length
+      expect(metrics.width).to eq(n * 4)
+      expect(metrics.height).to eq(n * 4)
+      expect(metrics.modules).to eq(n)
+    end
+
+    it 'uses the specified error correction level' do
+      low = described_class.measure('hello', module_size: 1, error_correction: :low)
+      high = described_class.measure('hello', module_size: 1, error_correction: :high)
+      # Higher correction -> more modules (for non-trivial data)
+      expect(high.modules).to be >= low.modules
+    end
+
+    it 'raises ArgumentError for an unknown error_correction level' do
+      expect { described_class.measure('hello', module_size: 4, error_correction: :bad) }
+        .to raise_error(ArgumentError, /unknown error_correction: :bad/)
+    end
+  end
+
+  describe '.resolve_level' do
+    %i[low medium quartile high].each do |level|
+      it "resolves :#{level}" do
+        expect(described_class.resolve_level(level)).to eq(described_class::LEVEL_MAP[level])
+      end
+    end
+
+    it 'raises ArgumentError for unknown level' do
+      expect { described_class.resolve_level(:extreme) }
+        .to raise_error(ArgumentError, /unknown error_correction/)
+    end
+  end
+
+  describe 'dependency guard' do
+    before do
+      hide_const('RQRCode') if defined?(RQRCode)
+      # Stub the private require_rqrcode! to simulate missing gem
+      allow(described_class).to receive(:require).with('rqrcode').and_raise(LoadError)
+    end
+
+    it 'raises DependencyError when rqrcode is not installed' do
+      expect { described_class.measure('test', module_size: 4) }
+        .to raise_error(ChromaWave::DependencyError, /rqrcode is required/)
+    end
+  end
+end

--- a/spec/chroma_wave/qr_spec.rb
+++ b/spec/chroma_wave/qr_spec.rb
@@ -33,12 +33,13 @@ RSpec.describe ChromaWave::QR do
   end
 
   describe '.measure' do
-    it 'returns a Metrics with correct pixel dimensions' do
+    it 'returns a Metrics with correct pixel dimensions including default quiet zone' do
       metrics = described_class.measure('hello', module_size: 4)
       qr = RQRCode::QRCode.new('hello', level: :m)
       n = qr.modules.length
-      expect(metrics.width).to eq(n * 4)
-      expect(metrics.height).to eq(n * 4)
+      expected_px = (n + 8) * 4 # default quiet_zone: 4 -> 2*4 = 8 extra modules
+      expect(metrics.width).to eq(expected_px)
+      expect(metrics.height).to eq(expected_px)
       expect(metrics.modules).to eq(n)
     end
 
@@ -47,6 +48,28 @@ RSpec.describe ChromaWave::QR do
       high = described_class.measure('hello', module_size: 1, error_correction: :high)
       # Higher correction -> more modules (for non-trivial data)
       expect(high.modules).to be >= low.modules
+    end
+
+    it 'computes dimensions without quiet zone when quiet_zone: 0' do
+      metrics = described_class.measure('hello', module_size: 4, quiet_zone: 0)
+      qr = RQRCode::QRCode.new('hello', level: :m)
+      n = qr.modules.length
+      expect(metrics.width).to eq(n * 4)
+      expect(metrics.height).to eq(n * 4)
+    end
+
+    it 'includes explicit quiet zone in dimensions' do
+      metrics = described_class.measure('hello', module_size: 2, quiet_zone: 2)
+      qr = RQRCode::QRCode.new('hello', level: :m)
+      n = qr.modules.length
+      expected_px = (n + 4) * 2
+      expect(metrics.width).to eq(expected_px)
+    end
+
+    it 'returns same dimensions for default and explicit quiet_zone: 4' do
+      default_m = described_class.measure('hello', module_size: 3)
+      explicit_m = described_class.measure('hello', module_size: 3, quiet_zone: 4)
+      expect(default_m).to eq(explicit_m)
     end
 
     it 'raises ArgumentError for an unknown error_correction level' do

--- a/spec/support/pixel_helpers.rb
+++ b/spec/support/pixel_helpers.rb
@@ -69,4 +69,21 @@ module PixelHelpers
     end
     canvas.width
   end
+
+  # Returns the bounding box width and height of all non-white pixels.
+  #
+  # @param canvas [ChromaWave::Canvas] the canvas to inspect
+  # @return [Array(Integer, Integer)] [width, height] of the non-white region
+  def non_white_extent(canvas)
+    max_x = max_y = 0
+    canvas.width.times do |x|
+      canvas.height.times do |y|
+        if canvas.get_pixel(x, y) != ChromaWave::Color::WHITE
+          max_x = x if x > max_x
+          max_y = y if y > max_y
+        end
+      end
+    end
+    [max_x + 1, max_y + 1]
+  end
 end


### PR DESCRIPTION
## Summary

Adds first-class QR code and barcode rendering to ChromaWave. Surfaces gain `draw_qr` and `draw_barcode` methods that compose on `fill_rect`, working across Canvas, Layer, and Framebuffer. Standalone `QR.measure` and `Barcode.measure` helpers let callers compute pixel dimensions for layout planning before drawing. Dependencies on `rqrcode` and `barby` are optional and lazily loaded with clear error messages.

## Changes

- **`lib/chroma_wave/qr.rb`** — New `ChromaWave::QR` module with `Metrics` value object, `.measure`, `.resolve_level`, and lazy `rqrcode` loading
- **`lib/chroma_wave/barcode.rb`** — New `ChromaWave::Barcode` module with `Metrics` value object, `.measure`, `.encode`, symbology registry (`SYMBOLOGIES`), and lazy `barby` loading
- **`lib/chroma_wave/drawing/codes.rb`** — New `Drawing::Codes` mixin providing `#draw_qr` and `#draw_barcode` on all surfaces; includes auto-fit sizing, quiet zone support, run-length bar rendering, and optional text labels
- **`lib/chroma_wave/surface.rb`** — Requires `drawing/codes`
- **`lib/chroma_wave.rb`** — Requires `qr` and `barcode` modules
- **`Gemfile` / `Gemfile.lock`** — Adds `rqrcode` and `barby` as optional runtime dependencies
- **`chroma_wave.gemspec`** — Removes hard gem dependencies (moved to optional Gemfile entries)
- **`spec/chroma_wave/qr_spec.rb`** — Full coverage for `QR.measure`, error correction resolution, dependency error handling
- **`spec/chroma_wave/barcode_spec.rb`** — Full coverage for `Barcode.measure`, `.encode`, symbology validation, text_font validation
- **`spec/chroma_wave/drawing/codes_spec.rb`** — Integration specs for `draw_qr` and `draw_barcode` on a mock surface, including background, quiet zone, auto-fit, text rendering, and error cases
- **`spec/support/pixel_helpers.rb`** — Test helper for pixel inspection

## Type of Change

- [x] `feat:` New feature — QR code and barcode rendering
- [x] `refactor:` Barcode module extraction, API consolidation
- [x] `docs:` RDoc for all public and private methods, Framebuffer color caveat notes
- [x] `fix:` Background extends to cover text area, text_font validation

## Testing

- 526 lines of RSpec specs across 3 new spec files
- `QR.measure` — validates pixel math, error correction mapping, and `DependencyError` when rqrcode is missing
- `Barcode.measure` — validates width/height calculations with and without text, symbology lookup, and encoding correctness
- `Drawing::Codes` — integration tests on a mock surface verifying `fill_rect` calls for QR modules, barcode bars, backgrounds, quiet zones, auto-fit sizing, text rendering, and argument validation
- All specs pass with `--fail-fast`

## Notes for Reviewers

- `rqrcode` and `barby` are **optional** dependencies — they're loaded lazily and raise `ChromaWave::DependencyError` with install instructions if missing
- Barcode rendering uses run-length scanning (one `fill_rect` per dark run) rather than per-module calls for efficiency
- QR auto-fit (`max_width`/`max_height`) picks the largest `module_size` that fits, with a floor of 1px
- `include_text: true` on barcodes requires a text-capable surface (Canvas/Layer) — raises on Framebuffer
- The `quiet_zone` parameter defaults to 4 modules per QR spec recommendation

## How this Makes You Feel

### 📱🏷️📊🖨️✨